### PR TITLE
Use mimalloc to improve performance and reduce memory allocation lock contention

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,6 +187,8 @@ jobs:
         sc config "postgresql-x64-14" start= auto
     - name: get psqlodbc
       uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: 'setup msvc for psqlodbc'
       uses: TheMrMilchmann/setup-msvc-dev@v3
       with: 
@@ -201,19 +203,19 @@ jobs:
       shell: powershell
       run: |
         winbuild\regress.ps1 -DsnInfo "SERVER=localhost|DATABASE=contrib_regression|PORT=5432|UID=postgres|PWD=password"
-    - name: build psqlodbc with UseMimalloc
+    - name: build psqlodbc with mimalloc
       shell: powershell      
       run: |
         copy .github\workflows\configuration.xml winbuild
-        winbuild\BuildAll.ps1 -UseMimalloc yes
+        winbuild\BuildAll.ps1 -UseMimalloc
       env:
-        PSQLODBC_OBJBASE: ${{ github.workspace }}/out/UseMimalloc
-    - name: test psqlodbc with UseMimalloc
+        PSQLODBC_OBJBASE: ${{ github.workspace }}/out/mimalloc
+    - name: test psqlodbc with mimalloc
       shell: powershell
       run: |
-        winbuild\regress.ps1 -DsnInfo "SERVER=localhost|DATABASE=contrib_regression|PORT=5432|UID=postgres|PWD=password"
+        winbuild\regress.ps1 -DsnInfo "SERVER=localhost|DATABASE=contrib_regression|PORT=5432|UID=postgres|PWD=password" -ExpectMimalloc -ReinstallDriver
       env:
-        PSQLODBC_OBJBASE: ${{ github.workspace }}/out/UseMimalloc
+        PSQLODBC_OBJBASE: ${{ github.workspace }}/out/mimalloc
     - name: Upload x64 merge module
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,6 @@ env:
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
   BUILD_CONFIGURATION: Release
 
-  # Path to the directory where the build artifacts will be placed.
-  PSQLODBC_OBJBASE: ${{ github.workspace }}/out/default
-
 permissions:
   contents: read
 
@@ -193,63 +190,110 @@ jobs:
       uses: TheMrMilchmann/setup-msvc-dev@v3
       with: 
         arch: x86
-    - name: build psqlodbc
+
+    - name: build psqlodbc standard
       shell: powershell      
       run: |
         copy .github\workflows\configuration.xml winbuild
         winbuild\BuildAll.ps1
         installer\buildInstallers.ps1
-    - name: test psqlodbc
+      env:
+        PSQLODBC_OBJBASE: ${{ github.workspace }}\winbuild\standard
+    - name: test psqlodbc standard
       shell: powershell
       run: |
         winbuild\regress.ps1 -DsnInfo "SERVER=localhost|DATABASE=contrib_regression|PORT=5432|UID=postgres|PWD=password"
-    - name: build psqlodbc with mimalloc
+        standard\test_x86\RegisterRegdsn.exe uninstall_driver postgres_devw
+        standard\test_x64\RegisterRegdsn.exe uninstall_driver postgres_devw
+      env:
+        PSQLODBC_OBJBASE: ${{ github.workspace }}\winbuild\standard
+
+    - name: build psqlodbc mimalloc
       shell: powershell      
       run: |
         copy .github\workflows\configuration.xml winbuild
         winbuild\BuildAll.ps1 -UseMimalloc
+        installer\buildInstallers.ps1
       env:
-        PSQLODBC_OBJBASE: ${{ github.workspace }}/out/mimalloc
-    - name: test psqlodbc with mimalloc
+        PSQLODBC_OBJBASE: ${{ github.workspace }}\winbuild\mimalloc
+    - name: test psqlodbc mimalloc
       shell: powershell
       run: |
-        winbuild\regress.ps1 -DsnInfo "SERVER=localhost|DATABASE=contrib_regression|PORT=5432|UID=postgres|PWD=password" -ExpectMimalloc -ReinstallDriver
+        winbuild\regress.ps1 -DsnInfo "SERVER=localhost|DATABASE=contrib_regression|PORT=5432|UID=postgres|PWD=password" -ExpectMimalloc
+        mimalloc\test_x86\RegisterRegdsn.exe uninstall_driver postgres_devw
+        mimalloc\test_x64\RegisterRegdsn.exe uninstall_driver postgres_devw
       env:
-        PSQLODBC_OBJBASE: ${{ github.workspace }}/out/mimalloc
-    - name: Upload x64 merge module
+        PSQLODBC_OBJBASE: ${{ github.workspace }}\winbuild\mimalloc
+
+    - name: Upload standard x64 merge module
       uses: actions/upload-artifact@v4
       with:
-        name: psqlODBC x64 Merge Module
-        path: ./installer/x64/*.msm
+        name: psqlODBC Standard x64 Merge Module
+        path: winbuild/standard/installer/x64/*.msm
         retention-days: 5
         if-no-files-found: error
-    - name: Upload x64 installer package
+    - name: Upload standard x64 installer package
       uses: actions/upload-artifact@v4
       with:
-        name: psqlODBC x64 Installer
-        path: ./installer/x64/*.msi
+        name: psqlODBC Standard x64 Installer
+        path: winbuild/standard/installer/x64/*.msi
         retention-days: 5
         if-no-files-found: error
-    - name: Upload x86 merge module
+    - name: Upload standard x86 merge module
       uses: actions/upload-artifact@v4
       with:
-        name: psqlODBC x86 Merge Module
-        path: ./installer/x86/*.msm
+        name: psqlODBC Standard x86 Merge Module
+        path: winbuild/standard/installer/x86/*.msm
         retention-days: 5
         if-no-files-found: error
-    - name: Upload x86 installer package
+    - name: Upload standard x86 installer package
       uses: actions/upload-artifact@v4
       with:
-        name: psqlODBC x86 Installer
-        path: ./installer/x86/*.msi
+        name: psqlODBC Standard x86 Installer
+        path: winbuild/standard/installer/x86/*.msi
         retention-days: 5
         if-no-files-found: error
-    - name: Upload x64 setup
-      id: x64_setup
+    - name: Upload standard x64 setup
       uses: actions/upload-artifact@v4
       with:
-        name: psqlODBC x64 Setup
-        path: ./installer/psqlodbc-setup/bin/Release/psqlodbc-setup.exe
+        name: psqlODBC Standard x64 Setup
+        path: winbuild/standard/installer/psqlodbc-setup/bin/Release/psqlodbc-setup.exe
+        retention-days: 5
+        if-no-files-found: error
+
+    - name: Upload mimalloc x64 merge module
+      uses: actions/upload-artifact@v4
+      with:
+        name: psqlODBC mimalloc x64 Merge Module
+        path: winbuild/mimalloc/installer/x64/*.msm
+        retention-days: 5
+        if-no-files-found: error
+    - name: Upload mimalloc x64 installer package
+      uses: actions/upload-artifact@v4
+      with:
+        name: psqlODBC mimalloc x64 Installer
+        path: winbuild/mimalloc/installer/x64/*.msi
+        retention-days: 5
+        if-no-files-found: error
+    - name: Upload mimalloc x86 merge module
+      uses: actions/upload-artifact@v4
+      with:
+        name: psqlODBC mimalloc x86 Merge Module
+        path: winbuild/mimalloc/installer/x86/*.msm
+        retention-days: 5
+        if-no-files-found: error
+    - name: Upload mimalloc x86 installer package
+      uses: actions/upload-artifact@v4
+      with:
+        name: psqlODBC mimalloc x86 Installer
+        path: winbuild/mimalloc/installer/x86/*.msi
+        retention-days: 5
+        if-no-files-found: error
+    - name: Upload mimalloc x64 setup
+      uses: actions/upload-artifact@v4
+      with:
+        name: psqlODBC mimalloc x64 Setup
+        path: winbuild/mimalloc/installer/psqlodbc-setup/bin/Release/psqlodbc-setup.exe
         retention-days: 5
         if-no-files-found: error
 
@@ -261,4 +305,4 @@ jobs:
         draft: false
         prerelease: false
         token: ${{secrets.RELEASE_TOKEN}}
-        artifacts: "./installer/x86/*.msi,./installer/x86/*.msm,./installer/psqlodbc-setup/bin/Release/psqlodbc-setup.exe"
+        artifacts: "winbuild/standard/installer/x86/*.msi,winbuild/standard/installer/x86/*.msm,winbuild/standard/installer/psqlodbc-setup/bin/Release/psqlodbc-setup.exe"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ env:
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
   BUILD_CONFIGURATION: Release
 
+  # Path to the directory where the build artifacts will be placed.
+  PSQLODBC_OBJBASE: ${{ github.workspace }}/out/default
+
 permissions:
   contents: read
 
@@ -198,6 +201,19 @@ jobs:
       shell: powershell
       run: |
         winbuild\regress.ps1 -DsnInfo "SERVER=localhost|DATABASE=contrib_regression|PORT=5432|UID=postgres|PWD=password"
+    - name: build psqlodbc with UseMimalloc
+      shell: powershell      
+      run: |
+        copy .github\workflows\configuration.xml winbuild
+        winbuild\BuildAll.ps1 -UseMimalloc yes
+      env:
+        PSQLODBC_OBJBASE: ${{ github.workspace }}/out/UseMimalloc
+    - name: test psqlodbc with UseMimalloc
+      shell: powershell
+      run: |
+        winbuild\regress.ps1 -DsnInfo "SERVER=localhost|DATABASE=contrib_regression|PORT=5432|UID=postgres|PWD=password"
+      env:
+        PSQLODBC_OBJBASE: ${{ github.workspace }}/out/UseMimalloc
     - name: Upload x64 merge module
       uses: actions/upload-artifact@v4
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "libs/mimalloc"]
+	path = libs/mimalloc
+	url = https://github.com/microsoft/mimalloc
+	branch = master

--- a/inouealc.c
+++ b/inouealc.c
@@ -1,6 +1,7 @@
 #undef	_MEMORY_DEBUG_
 #include	"psqlodbc.h"
 
+#ifndef	_MIMALLOC_
 #ifdef	WIN32
 #ifdef	_DEBUG
 /* #include	<stdlib.h> */
@@ -10,6 +11,7 @@
 #include	<malloc.h>
 #endif /* _DEBUG */
 #endif /* WIN32 */
+#endif /* _MIMALLOC_ */
 #include	<string.h>
 
 #include	"misc.h"
@@ -26,20 +28,20 @@ CSTR	ALCERR	= "alcerr";
 void * pgdebug_alloc(size_t size)
 {
 	void * alloced;
-	alloced = malloc(size);
+	alloced = pg_malloc(size);
 MYLOG(2, " alloced=%p(" FORMAT_SIZE_T ")\n", alloced, size);
 	if (alloced)
 	{
 		if (!alsize)
 		{
 			alsize = 100;
-			altbl = (ALADR *) malloc(alsize * sizeof(ALADR));
+			altbl = (ALADR *) pg_malloc(alsize * sizeof(ALADR));
 		}
 		else if (tbsize >= alsize)
 		{
 			ALADR *al;
 			alsize *= 2;
-			if (al = (ALADR *) realloc(altbl, alsize * sizeof(ALADR)), NULL == al)
+			if (al = (ALADR *) pg_realloc(altbl, alsize * sizeof(ALADR)), NULL == al)
 				return alloced;
 			altbl = al;
 		}
@@ -53,20 +55,20 @@ MYLOG(2, " alloced=%p(" FORMAT_SIZE_T ")\n", alloced, size);
 }
 void * pgdebug_calloc(size_t n, size_t size)
 {
-	void * alloced = calloc(n, size);
+	void * alloced = pg_calloc(n, size);
 
 	if (alloced)
 	{
 		if (!alsize)
 		{
 			alsize = 100;
-			altbl = (ALADR *) malloc(alsize * sizeof(ALADR));
+			altbl = (ALADR *) pg_malloc(alsize * sizeof(ALADR));
 		}
 		else if (tbsize >= alsize)
 		{
 			ALADR *al;
 			alsize *= 2;
-			if (al = (ALADR *) realloc(altbl, alsize * sizeof(ALADR)), NULL == al)
+			if (al = (ALADR *) pg_realloc(altbl, alsize * sizeof(ALADR)), NULL == al)
 				return alloced;
 			altbl = al;
 		}
@@ -85,7 +87,7 @@ void * pgdebug_realloc(void * ptr, size_t size)
 
 	if (!ptr)
 		return pgdebug_alloc(size);
-	alloced = realloc(ptr, size);
+	alloced = pg_realloc(ptr, size);
 	if (!alloced)
 	{
 		MYLOG(0, "%s %p error\n", ALCERR, ptr);
@@ -109,7 +111,7 @@ void * pgdebug_realloc(void * ptr, size_t size)
 }
 char * pgdebug_strdup(const char * ptr)
 {
-	char * alloced = strdup(ptr);
+	char * alloced = pg_strdup(ptr);
 	if (!alloced)
 	{
 		MYLOG(0, "%s %p error\n", ALCERR, ptr);
@@ -119,13 +121,13 @@ char * pgdebug_strdup(const char * ptr)
 		if (!alsize)
 		{
 			alsize = 100;
-			altbl = (ALADR *) malloc(alsize * sizeof(ALADR));
+			altbl = (ALADR *) pg_malloc(alsize * sizeof(ALADR));
 		}
 		else if (tbsize >= alsize)
 		{
 			ALADR *al;
 			alsize *= 2;
-			if (al = (ALADR *) realloc(altbl, alsize * sizeof(ALADR)), NULL == al)
+			if (al = (ALADR *) pg_realloc(altbl, alsize * sizeof(ALADR)), NULL == al)
 				return alloced;
 			altbl = al;
 		}
@@ -168,7 +170,7 @@ void pgdebug_free(void * ptr)
 	}
 	else
 		MYLOG(2, "ptr=%p\n", ptr);
-	free(ptr);
+	pg_free(ptr);
 }
 
 static BOOL out_check(void *out, size_t len, const char *name)
@@ -253,7 +255,7 @@ void debug_memory_check(void)
 	if (0 == tbsize)
 	{
 		MYLOG(0, "no memry leak found and max count allocated so far is %d\n", alsize);
-		free(altbl);
+		pg_free(altbl);
 		alsize = 0;
 	}
 	else

--- a/psqlodbc.h
+++ b/psqlodbc.h
@@ -24,6 +24,9 @@
 #endif
 #include "version.h"
 
+#ifdef	_MIMALLOC_
+#include <stdlib.h>
+#else /* _MIMALLOC_ */
 #ifdef	WIN32
 #ifdef	_DEBUG
 #ifndef	_MEMORY_DEBUG_
@@ -40,6 +43,11 @@
 #include <stdbool.h>
 #else  /* WIN32 */
 #include <stdlib.h>
+#endif /* WIN32 */
+#endif /* _MIMALLOC_ */
+
+#ifdef	WIN32
+#include <stdbool.h>
 #endif /* WIN32 */
 
 #ifdef  __INCLUDE_POSTGRES_FE_H__ /* currently not defined */
@@ -60,6 +68,21 @@
 #define pg_attribute_printf(f,a)
 #endif  /* __GNUC__ || __IBMC__ */
 #endif  /* __INCLUDE_POSTGRES_FE_H__ */
+
+#ifdef	_MIMALLOC_
+#include <mimalloc.h>
+#define pg_malloc	mi_malloc
+#define pg_realloc 	mi_realloc
+#define pg_calloc	mi_calloc
+#define pg_strdup	mi_strdup
+#define pg_free		mi_free
+#else  /* _MIMALLOC_ */
+#define pg_malloc	malloc
+#define pg_realloc 	realloc
+#define pg_calloc	calloc
+#define pg_strdup	_strdup
+#define pg_free		free
+#endif /* _MIMALLOC_ */
 
 #ifdef	_MEMORY_DEBUG_
 void		*pgdebug_alloc(size_t);
@@ -87,6 +110,15 @@ void		debug_memory_check(void);
 /* #define strncpy_null	pgdebug_strncpy_null */
 #define memcpy	pgdebug_memcpy
 #define memset	pgdebug_memset
+#else   /* _MEMORY_DEBUG_ */
+#ifdef	WIN32
+#undef strdup
+#endif /* WIN32 */
+#define malloc	pg_malloc
+#define realloc pg_realloc
+#define calloc	pg_calloc
+#define strdup	pg_strdup
+#define free	pg_free
 #endif   /* _MEMORY_DEBUG_ */
 
 #ifdef	WIN32

--- a/winbuild/BuildAll.ps1
+++ b/winbuild/BuildAll.ps1
@@ -31,9 +31,8 @@
     the configuration file other than standard one.
     The relative path is relative to the current directory.
 .PARAMETER UseMimalloc
-    Whether to use the mimalloc allocator for improved performance.
-	Requires a toolset of v141, v142 or later. Specify "yes" or
-	"no"(default).
+    Specify whether to use the mimalloc allocator for improved performance.
+	Requires a toolset of v141, v142 or later.
 .EXAMPLE
     > .\BuildAll
 	Build with default or automatically selected parameters.
@@ -70,8 +69,7 @@ Param(
 [String]$Configuration="Release",
 [string]$BuildConfigPath,
 [switch]$AlongWithInstallers,
-[ValidateSet("yes", "no")]
-[string]$UseMimalloc="no"
+[switch]$UseMimalloc
 )
 
 function buildPlatform([xml]$configInfo, [string]$Platform)
@@ -107,7 +105,9 @@ function buildPlatform([xml]$configInfo, [string]$Platform)
 		$macroList = iex "write-output $BUILD_MACROS"
 	}
 
-	if ($UseMimalloc -eq "yes") {
+	if ($UseMimalloc) {
+		$mimallocProperty = "yes"
+
 		switch ($VCVersion) {
 			"10.0"	{ $mimallocIdeDir = "vs2017" }
 			"11.0"	{ $mimallocIdeDir = "vs2017" }
@@ -124,7 +124,7 @@ function buildPlatform([xml]$configInfo, [string]$Platform)
 	}
 
 	# build psqlodbc
-	& ${msbuildexe} ./platformbuild.vcxproj /tv:$MSToolsV "/p:Platform=$Platform;Configuration=$Configuration;PlatformToolset=${Toolset}" /t:$target /p:VisualStudioVersion=${VCVersion} /p:DRIVERVERSION=$DRIVERVERSION /p:PG_INC=$PG_INC /p:PG_LIB=$PG_LIB /p:PG_BIN=$PG_BIN /p:MIMALLOC=$UseMimalloc $macroList
+	& ${msbuildexe} ./platformbuild.vcxproj /tv:$MSToolsV "/p:Platform=$Platform;Configuration=$Configuration;PlatformToolset=${Toolset}" /t:$target /p:VisualStudioVersion=${VCVersion} /p:DRIVERVERSION=$DRIVERVERSION /p:PG_INC=$PG_INC /p:PG_LIB=$PG_LIB /p:PG_BIN=$PG_BIN /p:MIMALLOC=$mimallocProperty $macroList
 }
 
 $scriptPath = (Split-Path $MyInvocation.MyCommand.Path)

--- a/winbuild/psqlodbc.vcxproj
+++ b/winbuild/psqlodbc.vcxproj
@@ -131,6 +131,13 @@
   <PropertyGroup Condition="'$(MEMORY_DEBUG)'=='yes'" >
     <ADD_DEFINES>$(ADD_DEFINES);_MEMORY_DEBUG_</ADD_DEFINES>
   </PropertyGroup>
+  <!-- MIMALLOC -->
+  <PropertyGroup Condition="'$(MIMALLOC)'=='yes'" >
+    <ADD_DEFINES>$(ADD_DEFINES);_MIMALLOC_</ADD_DEFINES>
+    <ADD_INC>$(ADD_INC);..\libs\mimalloc\include</ADD_INC>
+    <ADD_LIBPATH>$(ADD_LIBPATH);..\libs\mimalloc\out\msvc-$(Platform)\$(Configuration)</ADD_LIBPATH>
+    <CALL_LIB>$(CALL_LIB);mimalloc-static.lib</CALL_LIB>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
@@ -158,7 +165,7 @@
     <Link>
       <DelayLoadDLLs>$(DELAY_LOAD_DLLS);%(DelayLoadDLLs)</DelayLoadDLLs>
       <AdditionalLibraryDirectories>$(ADD_LIBPATH);$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libpq.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;wsock32.lib;ws2_32.lib;secur32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(CALL_LIB);libpq.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;wsock32.lib;ws2_32.lib;secur32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(MAINDEF)</ModuleDefinitionFile>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
     </Link>
@@ -177,7 +184,7 @@
     <Link>
       <DelayLoadDLLs>$(DELAY_LOAD_DLLS);%(DelayLoadDLLs)</DelayLoadDLLs>
       <AdditionalLibraryDirectories>$(ADD_LIBPATH);$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libpq.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;wsock32.lib;ws2_32.lib;secur32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(CALL_LIB);libpq.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;wsock32.lib;ws2_32.lib;secur32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(MAINDEF)</ModuleDefinitionFile>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
     </Link>
@@ -196,7 +203,7 @@
     <Link>
       <DelayLoadDLLs>$(DELAY_LOAD_DLLS);%(DelayLoadDLLs)</DelayLoadDLLs>
       <AdditionalLibraryDirectories>$(ADD_LIBPATH);$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libpq.lib;winmm.lib;wsock32.lib;ws2_32.lib;secur32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(CALL_LIB);libpq.lib;winmm.lib;wsock32.lib;ws2_32.lib;secur32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(MAINDEF)</ModuleDefinitionFile>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
     </Link>
@@ -215,7 +222,7 @@
     <Link>
       <DelayLoadDLLs>$(DELAY_LOAD_DLLS);%(DelayLoadDLLs)</DelayLoadDLLs>
       <AdditionalLibraryDirectories>$(ADD_LIBPATH);$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libpq.lib;winmm.lib;wsock32.lib;ws2_32.lib;secur32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(CALL_LIB);libpq.lib;winmm.lib;wsock32.lib;ws2_32.lib;secur32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(MAINDEF)</ModuleDefinitionFile>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
     </Link>


### PR DESCRIPTION
We have a multi-threaded Windows application that was experiencing delays due to high lock contention in memory allocations from the PostgreSQL ODBC driver. We tried modifying the driver to use [mimalloc](https://github.com/microsoft/mimalloc), which is a memory allocator with better performance characteristics. After deploying this change, the delays due to lock contention disappeared. It has been running on thousands of our production deployments for 9 months without issue.

I've created this pull request so that others can benefit from this change by building the driver with the `_MIMALLOC_` symbol defined and linking to the mimalloc library. If building on Windows, `BuildAll.ps1` accepts a `-UseMimalloc` argument that does this for you (requires a toolset of `v141`, `v142` or later). Below is an example of how to build with mimalloc on Windows:

```
.\BuildAll.ps1 -Platform x64 -Toolset v141 -UseMimalloc
```

Currently the usage of mimalloc is off by default, but I'd like to get people's thoughts on whether it should be enabled by default.
