### PR TITLE
Support building against VC17 on AMD64

### DIFF
--- a/winbuild/MSProgram-Get.psm1
+++ b/winbuild/MSProgram-Get.psm1
@@ -116,7 +116,7 @@ function Find-MSBuild
 	} catch {}
 	if ("$msbuildexe" -eq "") {
 		Write-Debug "tools version $toolsnum"
-		if ($toolsnum -gt 14) {	# VC15 ~ VC16
+		if ($toolsnum -gt 14) {	# VC15 ~ VC??
 			$msbuildexe = msbfind_15_xx $toolsnum
 		} else {			# VC10 ~ VC14
 			$msbuildexe = msbfind_10_14 "${toolsnum}.0"
@@ -203,7 +203,7 @@ function msbfind_10_14
 	return "${msbindir}msbuild"
 }
 
-#	find msbuild.exe for VC15 ~ VC16
+#	find msbuild.exe for VC15 ~ VC??
 function msbfind_15_xx
 {
     [CmdletBinding()]
@@ -243,7 +243,7 @@ function Find-Dumpbin
 #		$dumpbinexe="$env:DUMPBINEXE"
 		if ($dumpbinexe -eq "") {
 			$searching = $true
-			for ($i = $CurMaxVc; $searching -and ($i -ge 14); $i--)	# VC15 ~ VC16
+			for ($i = $CurMaxVc; $searching -and ($i -ge 14); $i--)	# VC15 ~ VC??
 			{
 				$vsdir = Find-VSDir $i
 				if ("$vsdir" -ne "") {
@@ -365,7 +365,7 @@ function Find-VSDir
 	if ((env_vcversion_no) -eq $vcversion_no) {
 		return $env:VSINSTALLDIR
 	}
-	if ($vcversion_no -gt 14) {	# VC15 ~ VC16
+	if ($vcversion_no -gt 14) {	# VC15 ~ VC??
 		return find_vsdir_15_xx ${vcversion_no}
 	} else {	# VC10 ~ VC14
 		$comntools = [environment]::getenvironmentvariable("VS${vcversion_no}0COMNTOOLS")
@@ -378,7 +378,7 @@ function Find-VSDir
 
 [bool]$vssetup_available = $true
 $vssetup = $null
-#	find vs installation path for VC15 ~ VC16
+#	find vs installation path for VC15 ~ VC??
 function find_vs_installation
 {
     [CmdletBinding()]
@@ -406,7 +406,7 @@ function find_vs_installation
 }
 
 $vsarray = @{VC15 = "2017"; VC16 = "2019"; VC17 = "2022"}
-#	find VS dir for VC15 ~ VC16
+#	find VS dir for VC15 ~ VC??
 function find_default_msbuild_path
 {
     [CmdletBinding()]
@@ -418,7 +418,8 @@ function find_default_msbuild_path
 	if ($vsdir -eq "")
 	{
 		$toolsnum = [int]$toolsver
-		if ($env:PROCESSOR_ARCHITECTURE -eq "x86" -or $env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+		# As of Visual Studio 2022 (VC17), MSBuild is 64-bit and so is always in ProgramFiles
+		if ($env:PROCESSOR_ARCHITECTURE -eq "x86" -or $toolsver -ge 17) {
 			$pgmfs = "$env:ProgramFiles"
 		} else {
 			$pgmfs = "${env:ProgramFiles(x86)}"
@@ -436,7 +437,7 @@ function find_default_msbuild_path
 	return ""
 }
 
-#	find VS dir for VC15 ~ VC16
+#	find VS dir for VC15 ~ VC??
 function find_vsdir_15_xx
 {
     [CmdletBinding()]


### PR DESCRIPTION
On my AMD64 machine, the build script was incorrectly looking for MSBuild 17 under `Program Files (x86)`. MSBuild [changed to 64-bit in Visual Studio 2022](https://learn.microsoft.com/en-us/visualstudio/ide/whats-new-visual-studio-2022?view=vs-2022#visual-studio-2022-is-64-bit), so it should always be under `Program Files`.