### PR TITLE
Add mimalloc release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -315,11 +315,25 @@ jobs:
         retention-days: 5
         if-no-files-found: error
 
-    - name: Create Release
+    - name: Create mimalloc Release
       if: startsWith(github.ref, 'refs/tags/REL-')
       uses: ncipollo/release-action@v1.14.0
-      id: create_release
+      id: create_mimalloc_release
       with:
+        tag: ${{github.ref_name}}-mimalloc
+        commit: ${{github.sha}}
+        body: A build of ${{github.ref_name}} that uses the mimalloc allocator for improved performance.
+        makeLatest: false
+        draft: false
+        prerelease: false
+        token: ${{secrets.RELEASE_TOKEN}}
+        artifacts: "winbuild/mimalloc/installer/x64/*.ms?,winbuild/mimalloc/installer/x86/*.ms?,winbuild/mimalloc/installer/psqlodbc-setup/bin/Release/psqlodbc-setup.exe"
+    - name: Create Standard Release
+      if: startsWith(github.ref, 'refs/tags/REL-')
+      uses: ncipollo/release-action@v1.14.0
+      id: create_standard_release
+      with:
+        makeLatest: true
         draft: false
         prerelease: false
         token: ${{secrets.RELEASE_TOKEN}}


### PR DESCRIPTION
This PR creates a separate release for the mimalloc builds. This is needed because the mimalloc workflow artifacts have a limited retention period.
