### PR TITLE
Use strdup on non-Windows systems

### DIFF
--- a/psqlodbc.h
+++ b/psqlodbc.h
@@ -80,7 +80,11 @@
 #define pg_malloc	malloc
 #define pg_realloc 	realloc
 #define pg_calloc	calloc
+#ifndef WIN32
+#define pg_strdup	strdup
+#else
 #define pg_strdup	_strdup
+#endif /* WIN32 */
 #define pg_free		free
 #endif /* _MIMALLOC_ */
 


### PR DESCRIPTION
Prior to #6, psqlODBC only used `_strdup` on Windows builds. Although `_strdup` is part of ISO C and C++, it does not compile on all systems. 

Fixes #15.