### PR TITLE
Prevent mimalloc release tag recursively triggering another release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
     branches: [ "main" ]
     tags:
       - 'REL-*'
+      - '!REL-*-mimalloc'
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
@davecramer we have a problem with the mimalloc release recursively triggering new releases. Please cancel the workflow and delete all the mimalloc releases except for the first one ([REL-16_00_0005-mimalloc](https://github.com/postgresql-interfaces/psqlodbc/releases/tag/REL-16_00_0005-mimalloc)).

This PR will prevent the problem from reoccurring.
