### PR TITLE
Fix for issue #47 - double free of COL_INFO object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ windows-local.mak
 /Makefile.in
 /aclocal.m4
 /autom4te.cache/
+/autom4te.cache/*
 /config/
 /config.h
 /config.h.in
@@ -43,6 +44,7 @@ windows-local.mak
 /config.status
 /configure
 /libtool
+/psqlodbca.la
 /psqlodbcw.la
 /stamp-h1
 
@@ -106,6 +108,11 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+
+# Eclipse project options
+/.project
+/.cproject
+/.settings
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/connection.c
+++ b/connection.c
@@ -556,6 +556,7 @@ CC_clear_col_info(ConnectionClass *self, BOOL destroy)
 			/* Going through COL_INFO cache table and releasing coli objects. */
 			if (coli = self->col_info[i], NULL != coli)
 			{
+				MYLOG(0, "!!!refcnt %p:%d -> %d\n", coli, coli->refcnt, coli->refcnt - 1);
 				coli->refcnt--;
 				if (coli->refcnt <= 0)
 				{

--- a/parse.c
+++ b/parse.c
@@ -883,7 +883,7 @@ getColumnsInfo(ConnectionClass *conn, TABLE_INFO *wti, OID greloid, StatementCla
 		{
 			/* We have ready to use coli object. Cleaning it. */
 			tmp_refcnt = coli->refcnt; /* If we found coli with greloid, then some TABLE_INFO objects may have references to it -> save refcnt for them. */
-			tmp_refcnt--; /* Down the road we will increase refcnt again to account for the refernce from ConnectionClass object to coli object. */
+			tmp_refcnt--; /* Down the road we will increase refcnt again to account for the reference from ConnectionClass object to coli object. */
 			free_col_info_contents(coli);
 		}
 		else


### PR DESCRIPTION
* Fix for issue #47 - double free of COL_INFO object due to refcount breakage during reuse of directly found object in getColumnsInfo(...).
* One more possible memory leak of COL_INFO objects in getColumnsInfo(...).