### PR TITLE
Fix MSI error messages

### DIFF
--- a/installer/psqlodbc_cpu.wxs
+++ b/installer/psqlodbc_cpu.wxs
@@ -140,9 +140,9 @@
     </Upgrade>
 
     <CustomAction Id='AlreadyUpdated'
-                Error="the same version of [$(var.PKGNAME)] is already installed" />
+                Error="the same version of [ProductName] is already installed" />
     <CustomAction Id='NoDowngrade'
-                Error="a new version of [$(var.PKGNAME)] is already installed" />
+                Error="a new version of [ProductName] is already installed" />
     <CustomAction Id='NoMinorUpgrade'
                 Error="REINSTALL unavailable. Major upgrade is needed." />
     <CustomAction Id='NoReinstall'


### PR DESCRIPTION
Use the MSI property, not the WiX preprocessor variable (which was also wrongly used as a property name) so the product name actually appears in the error message instead of an empty string.