### PR TITLE
MSI improvements

### DIFF
--- a/installer/buildInstallers.ps1
+++ b/installer/buildInstallers.ps1
@@ -263,9 +263,6 @@ function buildInstaller([string]$CPUTYPE)
 		New-Item -ItemType directory -Path $CPUTYPE | Out-Null
 	}
 
-	$PRODUCTCODE = [GUID]::NewGuid()
-	Write-Host "PRODUCTCODE: $PRODUCTCODE"
-
 	try {
 		pushd "$scriptPath"
 
@@ -285,7 +282,7 @@ function buildInstaller([string]$CPUTYPE)
 
 		Write-Host ".`nBuilding psqlODBC installer database..."
 
-		candle -nologo "-dPlatform=$CPUTYPE" "-dVERSION=$VERSION" "-dSUBLOC=$SUBLOC" "-dPRODUCTCODE=$PRODUCTCODE" "-dINSTBASE=$INSTBASE" -o $INSTBASE\psqlodbc.wixobj psqlodbc_cpu.wxs
+		candle -nologo "-dPlatform=$CPUTYPE" "-dVERSION=$VERSION" "-dSUBLOC=$SUBLOC" "-dINSTBASE=$INSTBASE" -o $INSTBASE\psqlodbc.wixobj psqlodbc_cpu.wxs
 		if ($LASTEXITCODE -ne 0) {
 			throw "Failed to build installer database"
 		}

--- a/installer/buildInstallers.ps1
+++ b/installer/buildInstallers.ps1
@@ -269,7 +269,7 @@ function buildInstaller([string]$CPUTYPE)
 		Write-Host ".`nBuilding psqlODBC/$SUBLOC merge module..."
 		$BINBASE = GetObjbase ".."
 		$INSTBASE = GetObjbase ".\$CPUTYPE" "installer\$CPUTYPE"
-		candle -nologo $libpqRelArgs "-dPlatform=$CPUTYPE" "-dVERSION=$VERSION" "-dSUBLOC=$SUBLOC" "-dLIBPQBINDIR=$LIBPQBINDIR" "-dLIBPQMSVCDLL=$LIBPQMSVCDLL" "-dLIBPQMSVCSYS=$LIBPQMSVCSYS" "-dPODBCMSVCDLL=$PODBCMSVCDLL" "-dPODBCMSVPDLL=$PODBCMSVPDLL" "-dPODBCMSVCSYS=$PODBCMSVCSYS" "-dPODBCMSVPSYS=$PODBCMSVPSYS" "-dNoPDB=$NoPDB" "-dBINBASE=$BINBASE" -o $INSTBASE\psqlodbcm.wixobj psqlodbcm_cpu.wxs
+		candle -nologo -arch $CPUTYPE $libpqRelArgs "-dVERSION=$VERSION" "-dSUBLOC=$SUBLOC" "-dLIBPQBINDIR=$LIBPQBINDIR" "-dLIBPQMSVCDLL=$LIBPQMSVCDLL" "-dLIBPQMSVCSYS=$LIBPQMSVCSYS" "-dPODBCMSVCDLL=$PODBCMSVCDLL" "-dPODBCMSVPDLL=$PODBCMSVPDLL" "-dPODBCMSVCSYS=$PODBCMSVCSYS" "-dPODBCMSVPSYS=$PODBCMSVPSYS" "-dNoPDB=$NoPDB" "-dBINBASE=$BINBASE" -o $INSTBASE\psqlodbcm.wixobj psqlodbcm_cpu.wxs
 		if ($LASTEXITCODE -ne 0) {
 			throw "Failed to build merge module"
 		}
@@ -282,7 +282,7 @@ function buildInstaller([string]$CPUTYPE)
 
 		Write-Host ".`nBuilding psqlODBC installer database..."
 
-		candle -nologo "-dPlatform=$CPUTYPE" "-dVERSION=$VERSION" "-dSUBLOC=$SUBLOC" "-dINSTBASE=$INSTBASE" -o $INSTBASE\psqlodbc.wixobj psqlodbc_cpu.wxs
+		candle -nologo -arch $CPUTYPE "-dVERSION=$VERSION" "-dSUBLOC=$SUBLOC" "-dINSTBASE=$INSTBASE" -o $INSTBASE\psqlodbc.wixobj psqlodbc_cpu.wxs
 		if ($LASTEXITCODE -ne 0) {
 			throw "Failed to build installer database"
 		}

--- a/installer/modify_msi.vbs
+++ b/installer/modify_msi.vbs
@@ -34,19 +34,16 @@ Dim record
 Set record = view.Fetch
 Dim gFile, pos
 Do While not record Is Nothing
-gFile = record.StringData(1)
-If Left(gFile, 8) = "psqlodbc" Then
-	gFile = record.StringData(3)
-	' Check if the FileName field is ShortName|LongName
-	pos = InStr(record.StringData(3), "|")
-	If pos > 0 Then
-		' Omit the ShortName part
-		gFile = Mid(record.StringData(3), pos + 1)
-		WScript.echo record.StringData(3) & " -> " & gFile
-		' And update the field
-		record.StringData(3) = gFile
-		view.Modify msiViewModifyUpdate, record
-	End If
+' Check if the FileName field is ShortName|LongName
+gFile = record.StringData(3)
+pos = InStr(gFile, "|psqlodbc")
+If (pos > 0) Then
+	' Omit the ShortName part
+	gFile = Mid(gFile, pos + 1)
+	WScript.echo record.StringData(3) & " -> " & gFile
+	' And update the field
+	record.StringData(3) = gFile
+	view.Modify msiViewModifyUpdate, record
 End If
 Set record = view.Fetch
 Loop

--- a/installer/psqlodbc_cpu.wxs
+++ b/installer/psqlodbc_cpu.wxs
@@ -153,7 +153,7 @@
     <Custom Action='NoDowngrade' After='FindRelatedProducts'>NEWERFOUND AND NOT Installed</Custom>
     <Custom Action='NoReinstall' Before='ValidateProductID'>REINSTALLMODE AND NOT Installed</Custom>
     <Custom Action='NoMinorUpgrade' After='FindRelatedProducts'>UPGRADEFOUND AND REINSTALLMODE</Custom>
-    <RemoveExistingProducts After='InstallFinalize'>UPGRADEFOUND AND NOT Installed</RemoveExistingProducts>
+    <RemoveExistingProducts After='InstallInitialize'>UPGRADEFOUND AND NOT Installed</RemoveExistingProducts>
   </InstallExecuteSequence>
   </Product>
 </Wix>

--- a/installer/psqlodbc_cpu.wxs
+++ b/installer/psqlodbc_cpu.wxs
@@ -103,7 +103,7 @@
       </Feature>
 
     </Feature>
-    <Media Id="1" EmbedCab="yes" Cabinet="psqlodbc.cab"/>
+    <Media Id="1" EmbedCab="yes" Cabinet="psqlodbc.cab" CompressionLevel="high"/>
 
 <!-- Properties -->
 

--- a/installer/psqlodbc_cpu.wxs
+++ b/installer/psqlodbc_cpu.wxs
@@ -5,7 +5,6 @@
   <?define Platform = "x64" ?>
   <?define PKGNAME = "psqlODBC_x64" ?>
   <?define PGFOLDER = "ProgramFiles64Folder" ?>
-  <?define PRODID = "3E42F836-9204-4c42-B3C3-8680A0434875" ?>
   <?define CIDREG = "4D361F28-8F75-4c86-9A37-6C279967413D" ?>
   <?define CIDDOC = "0C745A85-4E55-4bab-BBF1-DCF51D92FCC5" ?>
   <?define CIDSMD = "{E6410EE8-96DC-4d84-8D07-94F8093BF3EF}" ?>
@@ -15,7 +14,6 @@
   <?define Platform = "x86" ?>
   <?define PKGNAME = "psqlODBC" ?>
   <?define PGFOLDER = "ProgramFilesFolder" ?>
-  <?define PRODID = "838E187D-8B7A-473d-B93C-C8E970B15D2B" ?>
   <?define CIDREG = "4F0C04EB-ADCB-4fa8-B6A3-E9F74EA693F8" ?>
   <?define CIDDOC = "89DDBC52-9F0D-4846-91DC-09EECC87E42E" ?>
   <?define CIDSMD = "{22288E09-B3B6-4181-907F-676099C20125}" ?>

--- a/installer/psqlodbc_cpu.wxs
+++ b/installer/psqlodbc_cpu.wxs
@@ -64,16 +64,16 @@
               </Component>
               <Merge Id="psqlodbcm" DiskId="1" Language="1033" SourceFile="$(var.MERGEM)" />
             </Directory>
-            <Directory Id="DOCSDIR" Name="docs">
+            <Directory Id="DOCSDIR" Name="docs" FileSource="../docs">
               <Component Id="docs" Guid="$(var.CIDDOC)">
-                <File Id="docs.README.txt" Name="README.txt" DiskId="1" Source="../docs/README.txt" KeyPath="yes" />
-                <File Id="docs.config.html" Name="config.html" DiskId="1" Source="../docs/config.html" />
-                <File Id="docs.config_opt.html" Name="config-opt.html" DiskId="1" Source="../docs/config-opt.html" />
-                <File Id="docs.release.html" Name="release.html" DiskId="1" Source="../docs/release.html" />
-                <File Id="docs.release_7.3.html" Name="release-7.3.html" DiskId="1" Source="../docs/release-7.3.html" />
-                <File Id="docs.unix_compilation.html" Name="unix-compilation.html" DiskId="1" Source="../docs/unix-compilation.html" />
-                <File Id="docs.win32_compilation.html" Name="win32-compilation.html" DiskId="1" Source="../docs/win32-compilation.html" />
-                <File Id="docs.editConfiguration.jpg" Name="editConfiguration.jpg" DiskId="1" Source="../docs/editConfiguration.jpg" />
+                <File Name="README.txt" KeyPath="yes" />
+                <File Name="config.html" />
+                <File Name="config-opt.html" />
+                <File Name="release.html" />
+                <File Name="release-7.3.html" />
+                <File Name="unix-compilation.html" />
+                <File Name="win32-compilation.html" />
+                <File Name="editConfiguration.jpg" />
 
                 <!-- <Shortcut Id="docs.index.html" Directory="SMDir" Name="Documentation index" Description="psqlODBC documentation, HOWTOs and FAQs" Advertise="yes" Show="normal" /> -->
               </Component>

--- a/installer/psqlodbc_cpu.wxs
+++ b/installer/psqlodbc_cpu.wxs
@@ -21,7 +21,7 @@
   <?define CIDSMD = "{22288E09-B3B6-4181-907F-676099C20125}" ?>
   <?define UPGCOD = "24BCA538-75A2-4a7f-B236-C99EFC2145DE" ?>
   <?define ALLUSERS = "1" ?>
-<?else?>	<!-- sys.BUILDARCH -->
+<?else?><!-- sys.BUILDARCH -->
   <?error Invalid build architecture ?>
 <?endif?>
 
@@ -114,38 +114,48 @@
 
 <!-- UI -->
 
-     <UIRef Id="WixUI_FeatureTree" />
-     <WixVariable Id="WixUILicenseRtf" Value="lgpl.rtf" />
-     <WixVariable Id="WixUIDialogBmp" Value="background.bmp" />
-     <WixVariable Id="WixUIBannerBmp" Value="banner.bmp" />
+    <UIRef Id="WixUI_FeatureTree" />
+    <WixVariable Id="WixUILicenseRtf" Value="lgpl.rtf" />
+    <WixVariable Id="WixUIDialogBmp" Value="background.bmp" />
+    <WixVariable Id="WixUIBannerBmp" Value="banner.bmp" />
 
 <!-- Upgrade -->
     <Upgrade Id="$(var.UPGCOD)">
       <UpgradeVersion OnlyDetect='yes' Property='SELFFOUND'
-      		    Minimum="$(var.VERSION)" IncludeMinimum='yes'
-      		    Maximum="$(var.VERSION)" IncludeMaximum='yes' />
+        Minimum="$(var.VERSION)" IncludeMinimum='yes'
+        Maximum="$(var.VERSION)" IncludeMaximum='yes' />
       <UpgradeVersion OnlyDetect='yes' Property='NEWERFOUND'
-      		    Minimum="$(var.VERSION)" IncludeMinimum='no' />
+        Minimum="$(var.VERSION)" IncludeMinimum='no' />
       <UpgradeVersion OnlyDetect='no' Property='UPGRADEFOUND'
-                    Minimum='8.3.0' IncludeMinimum='yes'
-      		    Maximum="$(var.VERSION)" IncludeMaximum='no' />
+        Minimum='8.3.0' IncludeMinimum='yes'
+        Maximum="$(var.VERSION)" IncludeMaximum='no' />
     </Upgrade>
 
     <CustomAction Id='AlreadyUpdated'
-                Error="the same version of [ProductName] is already installed" />
+      Error="the same version of [ProductName] is already installed" />
     <CustomAction Id='NoDowngrade'
-                Error="a new version of [ProductName] is already installed" />
+      Error="a new version of [ProductName] is already installed" />
     <CustomAction Id='NoMinorUpgrade'
-                Error="REINSTALL unavailable. Major upgrade is needed." />
+      Error="REINSTALL unavailable. Major upgrade is needed." />
     <CustomAction Id='NoReinstall'
-                Error="REINSTALL unavailable. Install the package first." />
+      Error="REINSTALL unavailable. Install the package first." />
 
-  <InstallExecuteSequence>
-    <Custom Action='AlreadyUpdated' After='FindRelatedProducts'>SELFFOUND AND NOT Installed</Custom>
-    <Custom Action='NoDowngrade' After='FindRelatedProducts'>NEWERFOUND AND NOT Installed</Custom>
-    <Custom Action='NoReinstall' Before='ValidateProductID'>REINSTALLMODE AND NOT Installed</Custom>
-    <Custom Action='NoMinorUpgrade' After='FindRelatedProducts'>UPGRADEFOUND AND REINSTALLMODE</Custom>
-    <RemoveExistingProducts After='InstallInitialize'>UPGRADEFOUND AND NOT Installed</RemoveExistingProducts>
-  </InstallExecuteSequence>
+    <InstallExecuteSequence>
+      <Custom Action='AlreadyUpdated' After='FindRelatedProducts'>
+        SELFFOUND AND NOT Installed
+      </Custom>
+      <Custom Action='NoDowngrade' After='FindRelatedProducts'>
+        NEWERFOUND AND NOT Installed
+      </Custom>
+      <Custom Action='NoReinstall' Before='ValidateProductID'>
+        REINSTALLMODE AND NOT Installed
+      </Custom>
+      <Custom Action='NoMinorUpgrade' After='FindRelatedProducts'>
+        UPGRADEFOUND AND REINSTALLMODE
+      </Custom>
+      <RemoveExistingProducts After='InstallInitialize'>
+        UPGRADEFOUND AND NOT Installed
+      </RemoveExistingProducts>
+    </InstallExecuteSequence>
   </Product>
 </Wix>

--- a/installer/psqlodbc_cpu.wxs
+++ b/installer/psqlodbc_cpu.wxs
@@ -1,22 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 
-<!-- Default to x86 platform -->
-<?ifndef var.Platform ?>
-  <?define Platform = "x86" ?>
-<?else?>
-  <?if $(var.Platform) != x64 and $(var.Platform) != x86 ?>
-    <?error Invalid Platform variable ?>
-  <?endif?>
-<?endif?>
-
-<?ifndef var.INSTBASE ?>
-  <?define INSTBASE = $(var.Platform) ?>
-<?endif?>
-
-<?if $(var.Platform) = x64 ?>
+<?if $(sys.BUILDARCH) = x64 ?>
+  <?define Platform = "x64" ?>
   <?define PKGNAME = "psqlODBC_x64" ?>
-  <?define BIT64 = "yes" ?>
   <?define PGFOLDER = "ProgramFiles64Folder" ?>
   <?define PRODID = "3E42F836-9204-4c42-B3C3-8680A0434875" ?>
   <?define CIDREG = "4D361F28-8F75-4c86-9A37-6C279967413D" ?>
@@ -24,9 +11,9 @@
   <?define CIDSMD = "{E6410EE8-96DC-4d84-8D07-94F8093BF3EF}" ?>
   <?define UPGCOD = "BBD29DF5-89F6-4b8b-BDC9-C3EA3A4AFDBB" ?>
   <?define ALLUSERS = "1" ?>
-<?else?>
+<?elseif $(sys.BUILDARCH) = x86 ?>
+  <?define Platform = "x86" ?>
   <?define PKGNAME = "psqlODBC" ?>
-  <?define BIT64 = "no" ?>
   <?define PGFOLDER = "ProgramFilesFolder" ?>
   <?define PRODID = "838E187D-8B7A-473d-B93C-C8E970B15D2B" ?>
   <?define CIDREG = "4F0C04EB-ADCB-4fa8-B6A3-E9F74EA693F8" ?>
@@ -34,6 +21,12 @@
   <?define CIDSMD = "{22288E09-B3B6-4181-907F-676099C20125}" ?>
   <?define UPGCOD = "24BCA538-75A2-4a7f-B236-C99EFC2145DE" ?>
   <?define ALLUSERS = "1" ?>
+<?else?>	<!-- sys.BUILDARCH -->
+  <?error Invalid build architecture ?>
+<?endif?>
+
+<?ifndef var.INSTBASE ?>
+  <?define INSTBASE = $(var.Platform) ?>
 <?endif?>
 
 <?define MERGEM = "$(var.INSTBASE)\psqlodbc_$(var.Platform).msm" ?>
@@ -55,7 +48,6 @@
       Comments="PostgreSQL ODBC Driver"
       Manufacturer="PostgreSQL Global Development Group"
       InstallerVersion="300"
-      Platform="$(var.Platform)"
       Languages="1033"
       Compressed="yes"
       SummaryCodepage="1252" />
@@ -67,13 +59,13 @@
         <Directory Id="BASEDIR" Name="psqlODBC">
           <Directory Id="SUBLOC" Name="$(var.SUBLOC)">
             <Directory Id="BINDIR" Name="bin">
-              <Component Id="registration" Guid="$(var.CIDREG)" Win64="$(var.BIT64)">
+              <Component Id="registration" Guid="$(var.CIDREG)">
                 <RegistryValue KeyPath="yes" Type="string" Root="HKLM" Key="Software\$(var.PKGNAME)" Name="Version" Value="$(var.VERSION)" />
               </Component>
               <Merge Id="psqlodbcm" DiskId="1" Language="1033" SourceFile="$(var.MERGEM)" />
             </Directory>
             <Directory Id="DOCSDIR" Name="docs">
-              <Component Id="docs" Guid="$(var.CIDDOC)" Win64="$(var.BIT64)">
+              <Component Id="docs" Guid="$(var.CIDDOC)">
                 <File Id="docs.README.txt" Name="README.txt" DiskId="1" Source="../docs/README.txt" KeyPath="yes" />
                 <File Id="docs.config.html" Name="config.html" DiskId="1" Source="../docs/config.html" />
                 <File Id="docs.config_opt.html" Name="config-opt.html" DiskId="1" Source="../docs/config-opt.html" />
@@ -91,7 +83,7 @@
       </Directory>
       <Directory Id="ProgramMenuFolder" Name="." SourceName="Programs">
         <Directory Id="SMDir" Name="$(var.PKGNAME)">
-            <Component Id="smdir" Guid="$(var.CIDSMD)" Win64="$(var.BIT64)">
+            <Component Id="smdir" Guid="$(var.CIDSMD)">
                 <RegistryValue KeyPath="yes" Type="string" Root="HKCU" Key="Software\$(var.PKGNAME)\SMDir Created" Value="y" />
                 <RemoveFolder Id="SMDir" On="uninstall" />
             </Component>

--- a/installer/psqlodbc_cpu.wxs
+++ b/installer/psqlodbc_cpu.wxs
@@ -42,7 +42,7 @@
 
   <Product
     Manufacturer="PostgreSQL Global Development Group"
-    Id="$(var.PRODUCTCODE)"
+    Id="*"
     UpgradeCode="$(var.UPGCOD)"
     Name="$(var.PKGNAME)"
     Version="$(var.VERSION)"

--- a/installer/psqlodbc_cpu.wxs
+++ b/installer/psqlodbc_cpu.wxs
@@ -120,42 +120,8 @@
     <WixVariable Id="WixUIBannerBmp" Value="banner.bmp" />
 
 <!-- Upgrade -->
-    <Upgrade Id="$(var.UPGCOD)">
-      <UpgradeVersion OnlyDetect='yes' Property='SELFFOUND'
-        Minimum="$(var.VERSION)" IncludeMinimum='yes'
-        Maximum="$(var.VERSION)" IncludeMaximum='yes' />
-      <UpgradeVersion OnlyDetect='yes' Property='NEWERFOUND'
-        Minimum="$(var.VERSION)" IncludeMinimum='no' />
-      <UpgradeVersion OnlyDetect='no' Property='UPGRADEFOUND'
-        Minimum='8.3.0' IncludeMinimum='yes'
-        Maximum="$(var.VERSION)" IncludeMaximum='no' />
-    </Upgrade>
-
-    <CustomAction Id='AlreadyUpdated'
-      Error="the same version of [ProductName] is already installed" />
-    <CustomAction Id='NoDowngrade'
-      Error="a new version of [ProductName] is already installed" />
-    <CustomAction Id='NoMinorUpgrade'
-      Error="REINSTALL unavailable. Major upgrade is needed." />
-    <CustomAction Id='NoReinstall'
-      Error="REINSTALL unavailable. Install the package first." />
-
-    <InstallExecuteSequence>
-      <Custom Action='AlreadyUpdated' After='FindRelatedProducts'>
-        SELFFOUND AND NOT Installed
-      </Custom>
-      <Custom Action='NoDowngrade' After='FindRelatedProducts'>
-        NEWERFOUND AND NOT Installed
-      </Custom>
-      <Custom Action='NoReinstall' Before='ValidateProductID'>
-        REINSTALLMODE AND NOT Installed
-      </Custom>
-      <Custom Action='NoMinorUpgrade' After='FindRelatedProducts'>
-        UPGRADEFOUND AND REINSTALLMODE
-      </Custom>
-      <RemoveExistingProducts After='InstallInitialize'>
-        UPGRADEFOUND AND NOT Installed
-      </RemoveExistingProducts>
-    </InstallExecuteSequence>
+    <MajorUpgrade
+      DowngradeErrorMessage="A newer version of [ProductName] is already installed"
+      Schedule="afterInstallInitialize" />
   </Product>
 </Wix>

--- a/installer/psqlodbcm_cpu.wxs
+++ b/installer/psqlodbcm_cpu.wxs
@@ -31,7 +31,7 @@
 <?else?>
   <?define SysFolder = "$(env.SystemRoot)\system32" ?>
 <?endif?>
-<?else?>	<!-- sys.BUILDARCH -->
+<?else?><!-- sys.BUILDARCH -->
   <?error Invalid build architecture ?>
 <?endif?>
 
@@ -51,165 +51,165 @@
 
     <Directory Id="TARGETDIR" Name="SourceDir">
 
-		<!-- The Component Guid Generation Seed is a guid that must be used
-			 when a Component with the generate guid directive ("*") is not
-			 rooted in a standard Windows Installer directory (for example,
-			 ProgramFilesFolder or CommonFilesFolder). It is recommended
-			 that this attribute be avoided and that developers install
-			 their Components under standard directories with unique names
-			 instead (for example, "ProgramFilesFolder\Company Name Product
-			 Name Version"). It is important to note that once a directory
-			 is assigned a Component Guid Generation Seed the value must not
-			 change until (and must be changed when) the path to that
-			 directory, including itself and all parent directories, changes.
-		-->
+      <!-- The Component Guid Generation Seed is a guid that must be used
+           when a Component with the generate guid directive ("*") is not
+           rooted in a standard Windows Installer directory (for example,
+           ProgramFilesFolder or CommonFilesFolder). It is recommended
+           that this attribute be avoided and that developers install
+           their Components under standard directories with unique names
+           instead (for example, "ProgramFilesFolder\Company Name Product
+           Name Version"). It is important to note that once a directory
+           is assigned a Component Guid Generation Seed the value must
+           not change until (and must be changed when) the path to that
+           directory, including itself and all parent directories,
+           changes.
+    -->
       <Directory Id="BINDIR" Name="." ComponentGuidGenerationSeed="495CEE94-BDB9-4309-9544-D98783259CD8">
-		<!-- PostgreSQL -->
-		<Component Id="psqlodbc.psqlodbc30a.dll">
-		  <File Name="psqlodbc30a.dll" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\psqlodbc30a.dll">
-			<ODBCDriver Id="Psqlodbc_9.0_Driver_ANSI" Name="PostgreSQL ANSI($(var.Platform))">
-				<Property Id="CPTimeout" Value="60"/>
-			</ODBCDriver>
-			<ODBCDriver Id="Psqlodbc_11_newid_Driver_ANSI" Name="PostgreSQL ANSI">
-				<Property Id="CPTimeout" Value="60"/>
-			</ODBCDriver>
-		  </File>
-		</Component>
-		<Component Id="psqlodbc.pgenlista.dll">
-		  <File Name="pgenlista.dll" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\pgenlista.dll" />
-		</Component>
+    <!-- PostgreSQL -->
+    <Component Id="psqlodbc.psqlodbc30a.dll">
+      <File Name="psqlodbc30a.dll" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\psqlodbc30a.dll">
+      <ODBCDriver Id="Psqlodbc_9.0_Driver_ANSI" Name="PostgreSQL ANSI($(var.Platform))">
+        <Property Id="CPTimeout" Value="60"/>
+      </ODBCDriver>
+      <ODBCDriver Id="Psqlodbc_11_newid_Driver_ANSI" Name="PostgreSQL ANSI">
+        <Property Id="CPTimeout" Value="60"/>
+      </ODBCDriver>
+      </File>
+    </Component>
+    <Component Id="psqlodbc.pgenlista.dll">
+      <File Name="pgenlista.dll" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\pgenlista.dll" />
+    </Component>
 <?if $(var.NoPDB) != True ?>
-		<Component Id="psqlodbc.psqlodbc30a.pdb">
-		  <File Name="psqlodbc30a.pdb" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\psqlodbc30a.pdb" />
-		</Component>
-		<Component Id="psqlodbc.pgenlista.pdb">
-		  <File Name="pgenlista.pdb" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\pgenlista.pdb" />
-		</Component>
+    <Component Id="psqlodbc.psqlodbc30a.pdb">
+      <File Name="psqlodbc30a.pdb" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\psqlodbc30a.pdb" />
+    </Component>
+    <Component Id="psqlodbc.pgenlista.pdb">
+      <File Name="pgenlista.pdb" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\pgenlista.pdb" />
+    </Component>
 <?endif?>
-		<Component Id="psqlodbc.psqlodbc35w.dll">
-		  <File Name="psqlodbc35w.dll" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\psqlodbc35w.dll">
-			<ODBCDriver Id="Psqlodbc_9.0_Driver" Name="PostgreSQL Unicode($(var.Platform))">
-				<Property Id="CPTimeout" Value="60"/>
-			</ODBCDriver>
-			<ODBCDriver Id="Psqlodbc_11_newid_Driver" Name="PostgreSQL Unicode">
-				<Property Id="CPTimeout" Value="60"/>
-			</ODBCDriver>
-		  </File>
-		</Component>
-		<Component Id="psqlodbc.pgenlist.dll">
-		  <File Name="pgenlist.dll" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\pgenlist.dll" />
-		</Component>
+    <Component Id="psqlodbc.psqlodbc35w.dll">
+      <File Name="psqlodbc35w.dll" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\psqlodbc35w.dll">
+      <ODBCDriver Id="Psqlodbc_9.0_Driver" Name="PostgreSQL Unicode($(var.Platform))">
+        <Property Id="CPTimeout" Value="60"/>
+      </ODBCDriver>
+      <ODBCDriver Id="Psqlodbc_11_newid_Driver" Name="PostgreSQL Unicode">
+        <Property Id="CPTimeout" Value="60"/>
+      </ODBCDriver>
+      </File>
+    </Component>
+    <Component Id="psqlodbc.pgenlist.dll">
+      <File Name="pgenlist.dll" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\pgenlist.dll" />
+    </Component>
 <?if $(var.NoPDB) != True ?>
-		<Component Id="psqlodbc.psqlodbc35w.pdb">
-		  <File Name="psqlodbc35w.pdb" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\psqlodbc35w.pdb" />
-		</Component>
-		<Component Id="psqlodbc.pgenlist.pdb">
-		  <File Name="pgenlist.pdb" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\pgenlist.pdb" />
-		</Component>
+    <Component Id="psqlodbc.psqlodbc35w.pdb">
+      <File Name="psqlodbc35w.pdb" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\psqlodbc35w.pdb" />
+    </Component>
+    <Component Id="psqlodbc.pgenlist.pdb">
+      <File Name="pgenlist.pdb" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\pgenlist.pdb" />
+    </Component>
 <?endif?>
 
-		<!-- MSVC Runtime -->
+    <!-- MSVC Runtime -->
 <?if "$(var.PODBCMSVCDLL)" != "" ?>
-		<Component Id="vcredist.vcruntime.dll.psqlodbc">
-		  <File Source="$(var.PODBCMSVCDLL)" />
-		</Component>
+    <Component Id="vcredist.vcruntime.dll.psqlodbc">
+      <File Source="$(var.PODBCMSVCDLL)" />
+    </Component>
 <?endif?>
 <?if "$(var.PODBCMSVPDLL)" != "" ?>
-		<Component Id="vcredist.msvcp.dll.psqlodbc">
-		  <File Source="$(var.PODBCMSVPDLL)" />
-		</Component>
+    <Component Id="vcredist.msvcp.dll.psqlodbc">
+      <File Source="$(var.PODBCMSVPDLL)" />
+    </Component>
 <?endif?>
 <?if "$(var.PODBCMSVCSYS)" != "" ?>
-		<Component Id="system.vcruntime.dll.psqlodbc">
-		  <File Source="$(var.SysFolder)\$(var.PODBCMSVCSYS)" />
-		</Component>
+    <Component Id="system.vcruntime.dll.psqlodbc">
+      <File Source="$(var.SysFolder)\$(var.PODBCMSVCSYS)" />
+    </Component>
 <?endif?>
 <?if "$(var.PODBCMSVPSYS)" != "" ?>
-		<Component Id="system.msvcp.dll.psqlodbc">
-		  <File Source="$(var.SysFolder)\$(var.PODBCMSVPSYS)" />
-		</Component>
+    <Component Id="system.msvcp.dll.psqlodbc">
+      <File Source="$(var.SysFolder)\$(var.PODBCMSVPSYS)" />
+    </Component>
 <?endif?>
 <?if "$(var.LIBPQMSVCDLL)" != "" ?>
-		<Component Id="vcredist.vcruntime.dll.libpq">
-		  <File Source="$(var.LIBPQMSVCDLL)" />
-		</Component>
+    <Component Id="vcredist.vcruntime.dll.libpq">
+      <File Source="$(var.LIBPQMSVCDLL)" />
+    </Component>
 <?endif?>
 <?if "$(var.LIBPQMSVCSYS)" != "" ?>
-		<Component Id="system.vcruntime.dll.libpq">
-		  <File Source="$(var.SysFolder)\$(var.LIBPQMSVCSYS)" />
-		</Component>
+    <Component Id="system.vcruntime.dll.libpq">
+      <File Source="$(var.SysFolder)\$(var.LIBPQMSVCSYS)" />
+    </Component>
 <?endif?>
 
-		<!-- libpq -->
-		<Component Id="libpq.libpq.dll">
-		  <File Id="libpq.dll" Name="libpq.dll" Source="$(var.LIBPQBINDIR)\libpq.dll" />
-		</Component>
+    <!-- libpq -->
+    <Component Id="libpq.libpq.dll">
+      <File Id="libpq.dll" Name="libpq.dll" Source="$(var.LIBPQBINDIR)\libpq.dll" />
+    </Component>
 <?if "$(var.LIBPQMEM0)" != "" ?>
-		<Component Id="libpq.related0.dll">
-		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM0)" />
-		</Component>
+    <Component Id="libpq.related0.dll">
+      <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM0)" />
+    </Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM1)" != "" ?>
-		<Component Id="libpq.related1.dll">
-		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM1)" />
-		</Component>
+    <Component Id="libpq.related1.dll">
+      <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM1)" />
+    </Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM2)" != "" ?>
-		<Component Id="libpq.related2.dll">
-		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM2)" />
-		</Component>
+    <Component Id="libpq.related2.dll">
+      <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM2)" />
+    </Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM3)" != "" ?>
-		<Component Id="libpq.related3.dll">
-		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM3)" />
-		</Component>
+    <Component Id="libpq.related3.dll">
+      <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM3)" />
+    </Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM4)" != "" ?>
-		<Component Id="libpq.related4.dll">
-		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM4)" />
-		</Component>
+    <Component Id="libpq.related4.dll">
+      <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM4)" />
+    </Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM5)" != "" ?>
-		<Component Id="libpq.related5.dll">
-		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM5)" />
-		</Component>
+    <Component Id="libpq.related5.dll">
+      <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM5)" />
+    </Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM6)" != "" ?>
-		<Component Id="libpq.related6.dll">
-		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM6)" />
-		</Component>
+    <Component Id="libpq.related6.dll">
+      <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM6)" />
+    </Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM7)" != "" ?>
-		<Component Id="libpq.related7.dll">
-		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM7)" />
-		</Component>
+    <Component Id="libpq.related7.dll">
+      <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM7)" />
+    </Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM8)" != "" ?>
-		<Component Id="libpq.related8.dll">
-		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM8)" />
-		</Component>
+    <Component Id="libpq.related8.dll">
+      <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM8)" />
+    </Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM9)" != "" ?>
-		<Component Id="libpq.related9.dll">
-		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM9)" />
-		</Component>
+    <Component Id="libpq.related9.dll">
+      <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM9)" />
+    </Component>
 <?endif ?>
 
-	<!--
-		MSDTC runs in 64bit mode on 64bit machines and 32bit mode on
-		32bit machines. We had better register the XA DLL on 
-		installation.
-	--> 
-		<Component Id="pgxalib.files">
-	<?if $(var.BIT64) = no ?>	<!-- On x64 OS only install from x64 package. -->
-		  <Condition>
-			<![CDATA[NOT VersionNT64]]>
-		  </Condition>
-	<?endif?>
-		  <File Name="pgxalib.dll" Source="$(var.BINBASE)/$(var.UNICODEFOLDER)/pgxalib.dll" />
-		  <RegistryValue Id="pgxalib.reg.1" Root="HKLM" Key="SOFTWARE\Microsoft\MSDTC\XADLL" Name="pgxalib.dll" Type="string" Value="[#pgxalib.dll]" />
-		</Component>
-	  </Directory>
+    <!-- MSDTC runs in 64bit mode on 64bit machines and 32bit mode on
+         32bit machines. We had better register the XA DLL on 
+         installation.
+    --> 
+    <Component Id="pgxalib.files">
+<?if $(var.BIT64) = no ?> <!-- On x64 OS only install from x64 package. -->
+      <Condition>
+      <![CDATA[NOT VersionNT64]]>
+      </Condition>
+<?endif?>
+      <File Name="pgxalib.dll" Source="$(var.BINBASE)/$(var.UNICODEFOLDER)/pgxalib.dll" />
+      <RegistryValue Id="pgxalib.reg.1" Root="HKLM" Key="SOFTWARE\Microsoft\MSDTC\XADLL" Name="pgxalib.dll" Type="string" Value="[#pgxalib.dll]" />
+    </Component>
+    </Directory>
     </Directory>
 
   </Module>

--- a/installer/psqlodbcm_cpu.wxs
+++ b/installer/psqlodbcm_cpu.wxs
@@ -20,8 +20,6 @@
   <?define ANSIFOLDER = "x64_ANSI_Release" ?>
   <?define UNICODEFOLDER = "x64_Unicode_Release" ?>
   <?define Module_PackageId = "970B6E07-7105-4d66-80FA-9E208952FB96" ?>
-  <?define CIDPFILES = "5C9A19B5-D7C6-4bb4-BBBC-88C2A67A59B0" ?>
-  <?define CIDXFILES = "121A6C41-2B8F-463D-BA84-6BF36701428A" ?>
   <?define InstallerVersion = "300" ?>
 <?if $(env.PROCESSOR_ARCHITECTURE) = "AMD64" ?>
   <?define SysFolder = "$(env.SystemRoot)\system32" ?>
@@ -34,8 +32,6 @@
   <?define ANSIFOLDER = "x86_ANSI_Release" ?>
   <?define UNICODEFOLDER = "x86_Unicode_Release" ?>
   <?define Module_PackageId = "ACF10866-5C01-46f0-90F0-D5618638CA48" ?>
-  <?define CIDPFILES = "00A1ACE3-B7C2-41b8-A1F1-DB565990DA4E" ?>
-  <?define CIDXFILES = "49933A1E-4350-437C-B8D5-E96AA5D61139" ?>
   <?define InstallerVersion = "150" ?>
 <?if $(env.PROCESSOR_ARCHITECTURE) = "AMD64" ?>
   <?define SysFolder = "$(env.SystemRoot)\syswow64" ?>
@@ -60,134 +56,192 @@
       SummaryCodepage="1252" />
 
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="BINDIR" Name=".">
-        <Component Id="psqlodbc.files" Guid="$(var.CIDPFILES)" Win64="$(var.BIT64)">
 
-          <!-- PostgreSQL -->
-          <File Id="psqlodbc30a.dll" Name="psqlodbc30a.dll" Source="$(var.BINBASE)/$(var.ANSIFOLDER)/psqlodbc30a.dll" />
+		<!-- The Component Guid Generation Seed is a guid that must be used
+			 when a Component with the generate guid directive ("*") is not
+			 rooted in a standard Windows Installer directory (for example,
+			 ProgramFilesFolder or CommonFilesFolder). It is recommended
+			 that this attribute be avoided and that developers install
+			 their Components under standard directories with unique names
+			 instead (for example, "ProgramFilesFolder\Company Name Product
+			 Name Version"). It is important to note that once a directory
+			 is assigned a Component Guid Generation Seed the value must not
+			 change until (and must be changed when) the path to that
+			 directory, including itself and all parent directories, changes.
+		-->
+      <Directory Id="BINDIR" Name="." ComponentGuidGenerationSeed="495CEE94-BDB9-4309-9544-D98783259CD8">
+		<!-- PostgreSQL -->
+		<Component Id="psqlodbc.psqlodbc30a.dll" Win64="$(var.BIT64)">
+		  <File Name="psqlodbc30a.dll" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\psqlodbc30a.dll" />
+		</Component>
+		<Component Id="psqlodbc.pgenlista.dll" Win64="$(var.BIT64)">
+		  <File Name="pgenlista.dll" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\pgenlista.dll" />
+		</Component>
 <?if $(var.NoPDB) != True ?>
-          <File Id="psqlodbc30a.pdb" Name="psqlodbc30a.pdb" Source="$(var.BINBASE)/$(var.ANSIFOLDER)/psqlodbc30a.pdb" />
+		<Component Id="psqlodbc.psqlodbc30a.pdb" Win64="$(var.BIT64)">
+		  <File Name="psqlodbc30a.pdb" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\psqlodbc30a.pdb" />
+		</Component>
+		<Component Id="psqlodbc.pgenlista.pdb" Win64="$(var.BIT64)">
+		  <File Name="pgenlista.pdb" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\pgenlista.pdb" />
+		</Component>
 <?endif?>
-          <File Id="psqlodbc35w.dll" Name="psqlodbc35w.dll" Source="$(var.BINBASE)/$(var.UNICODEFOLDER)/psqlodbc35w.dll" />
+		<Component Id="psqlodbc.psqlodbc35w.dll" Win64="$(var.BIT64)">
+		  <File Name="psqlodbc35w.dll" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\psqlodbc35w.dll" />
+		</Component>
+		<Component Id="psqlodbc.pgenlist.dll" Win64="$(var.BIT64)">
+		  <File Name="pgenlist.dll" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\pgenlist.dll" />
+		</Component>
 <?if $(var.NoPDB) != True ?>
-          <File Id="psqlodbc35w.pdb" Name="psqlodbc35w.pdb" Source="$(var.BINBASE)/$(var.UNICODEFOLDER)/psqlodbc35w.pdb" />
+		<Component Id="psqlodbc.psqlodbc35w.pdb" Win64="$(var.BIT64)">
+		  <File Name="psqlodbc35w.pdb" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\psqlodbc35w.pdb" />
+		</Component>
+		<Component Id="psqlodbc.pgenlist.pdb" Win64="$(var.BIT64)">
+		  <File Name="pgenlist.pdb" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\pgenlist.pdb" />
+		</Component>
 <?endif?>
-          <File Id="pgenlist.dll" Name="pgenlist.dll" Source="$(var.BINBASE)/$(var.UNICODEFOLDER)/pgenlist.dll" />
-<?if $(var.NoPDB) != True ?>
-          <File Id="pgenlist.pdb" Name="pgenlist.pdb" Source="$(var.BINBASE)/$(var.UNICODEFOLDER)/pgenlist.pdb" />
-<?endif?>
-          <File Id="pgenlista.dll" Name="pgenlista.dll" Source="$(var.BINBASE)/$(var.ANSIFOLDER)/pgenlista.dll" />
-<?if $(var.NoPDB) != True ?>
-          <File Id="pgenlista.pdb" Name="pgenlista.pdb" Source="$(var.BINBASE)/$(var.ANSIFOLDER)/pgenlista.pdb" />
-<?endif?>
-	<!-- MSVC Runtime -->
+
+		<!-- MSVC Runtime -->
 <?if "$(var.PODBCMSVCDLL)" != "" ?>
-          <File Source="$(var.PODBCMSVCDLL)" />
+		<Component Id="vcredist.vcruntime.dll.psqlodbc" Win64="$(var.BIT64)">
+		  <File Source="$(var.PODBCMSVCDLL)" />
+		</Component>
 <?endif?>
 <?if "$(var.PODBCMSVPDLL)" != "" ?>
-          <File Source="$(var.PODBCMSVPDLL)" />
+		<Component Id="vcredist.msvcp.dll.psqlodbc" Win64="$(var.BIT64)">
+		  <File Source="$(var.PODBCMSVPDLL)" />
+		</Component>
 <?endif?>
 <?if "$(var.PODBCMSVCSYS)" != "" ?>
-          <File Source="$(var.SysFolder)\$(var.PODBCMSVCSYS)" />
+		<Component Id="system.vcruntime.dll.psqlodbc" Win64="$(var.BIT64)">
+		  <File Source="$(var.SysFolder)\$(var.PODBCMSVCSYS)" />
+		</Component>
 <?endif?>
 <?if "$(var.PODBCMSVPSYS)" != "" ?>
-          <File Source="$(var.SysFolder)\$(var.PODBCMSVPSYS)" />
+		<Component Id="system.msvcp.dll.psqlodbc" Win64="$(var.BIT64)">
+		  <File Source="$(var.SysFolder)\$(var.PODBCMSVPSYS)" />
+		</Component>
 <?endif?>
 <?if "$(var.LIBPQMSVCDLL)" != "" ?>
-          <File Source="$(var.LIBPQMSVCDLL)" />
+		<Component Id="vcredist.vcruntime.dll.libpq" Win64="$(var.BIT64)">
+		  <File Source="$(var.LIBPQMSVCDLL)" />
+		</Component>
 <?endif?>
 <?if "$(var.LIBPQMSVCSYS)" != "" ?>
-          <File Source="$(var.SysFolder)\$(var.LIBPQMSVCSYS)" />
+		<Component Id="system.vcruntime.dll.libpq" Win64="$(var.BIT64)">
+		  <File Source="$(var.SysFolder)\$(var.LIBPQMSVCSYS)" />
+		</Component>
 <?endif?>
 
-          <File Id="libpq.dll" Name="libpq.dll" Source="$(var.LIBPQBINDIR)\libpq.dll" KeyPath="yes" />
-
-          <!-- libpq related -->
+		<!-- libpq -->
+		<Component Id="libpq.libpq.dll" Win64="$(var.BIT64)">
+		  <File Id="libpq.dll" Name="libpq.dll" Source="$(var.LIBPQBINDIR)\libpq.dll" />
+		</Component>
 <?if "$(var.LIBPQMEM0)" != "" ?>
-          <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM0)" />
+		<Component Id="libpq.related0.dll" Win64="$(var.BIT64)">
+		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM0)" />
+		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM1)" != "" ?>
-          <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM1)" />
+		<Component Id="libpq.related1.dll" Win64="$(var.BIT64)">
+		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM1)" />
+		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM2)" != "" ?>
-          <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM2)" />
+		<Component Id="libpq.related2.dll" Win64="$(var.BIT64)">
+		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM2)" />
+		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM3)" != "" ?>
-          <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM3)" />
+		<Component Id="libpq.related3.dll" Win64="$(var.BIT64)">
+		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM3)" />
+		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM4)" != "" ?>
-          <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM4)" />
+		<Component Id="libpq.related4.dll" Win64="$(var.BIT64)">
+		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM4)" />
+		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM5)" != "" ?>
-          <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM5)" />
+		<Component Id="libpq.related5.dll" Win64="$(var.BIT64)">
+		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM5)" />
+		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM6)" != "" ?>
-          <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM6)" />
+		<Component Id="libpq.related6.dll" Win64="$(var.BIT64)">
+		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM6)" />
+		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM7)" != "" ?>
-          <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM7)" />
+		<Component Id="libpq.related7.dll" Win64="$(var.BIT64)">
+		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM7)" />
+		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM8)" != "" ?>
-          <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM8)" />
+		<Component Id="libpq.related8.dll" Win64="$(var.BIT64)">
+		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM8)" />
+		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM9)" != "" ?>
-          <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM9)" />
+		<Component Id="libpq.related9.dll" Win64="$(var.BIT64)">
+		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM9)" />
+		</Component>
 <?endif ?>
 
-          <!-- Note, installing the driver properly (IE, using ODBCDriver) has
-               proven unreliable, so we install the registry keys manually
-               ourselves. On 64-bit Windows, however, we trust that ODBCDriver
-               works. Nowadays, it probably would be safe to use ODBCDriver on
-               all platforms, but no-one's gotten around to revisit this
-          -->
+		  <!-- Note, installing the driver properly (IE, using ODBCDriver) has
+			   proven unreliable, so we install the registry keys manually
+			   ourselves. On 64-bit Windows, however, we trust that ODBCDriver
+			   works. Nowadays, it probably would be safe to use ODBCDriver on
+			   all platforms, but no-one's gotten around to revisit this
+		  -->
+		<Component Id="psqlodbc.odbcdriver" Win64="$(var.BIT64)">
 <?if $(var.Platform) = x64 ?>
-          <ODBCDriver Id="Psqlodbc_9.0_Driver_ANSI" Name="PostgreSQL ANSI($(var.Platform))" File="psqlodbc30a.dll" />
-          <ODBCDriver Id="Psqlodbc_9.0_Driver" Name="PostgreSQL Unicode($(var.Platform))" File="psqlodbc35w.dll" />
-          <ODBCDriver Id="Psqlodbc_11_newid_Driver_ANSI" Name="PostgreSQL ANSI" File="psqlodbc30a.dll" />
-          <ODBCDriver Id="Psqlodbc_11_newid_Driver" Name="PostgreSQL Unicode" File="psqlodbc35w.dll" />
-          <RegistryValue Id="psqlodbc30a.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="CPTimeout" Type="string" Value="60" />
-          <RegistryValue Id="psqlodbc35w.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="CPTimeout" Type="string" Value="60" />
-          <RegistryValue Id="psqlodbc30a.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI($(var.Platform))" Name="CPTimeout" Type="string" Value="60" />
-          <RegistryValue Id="psqlodbc35w.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode($(var.Platform))" Name="CPTimeout" Type="string" Value="60" />
+		  <ODBCDriver Id="Psqlodbc_9.0_Driver_ANSI" Name="PostgreSQL ANSI($(var.Platform))" File="psqlodbc30a.dll" />
+		  <ODBCDriver Id="Psqlodbc_9.0_Driver" Name="PostgreSQL Unicode($(var.Platform))" File="psqlodbc35w.dll" />
+		  <ODBCDriver Id="Psqlodbc_11_newid_Driver_ANSI" Name="PostgreSQL ANSI" File="psqlodbc30a.dll" />
+		  <ODBCDriver Id="Psqlodbc_11_newid_Driver" Name="PostgreSQL Unicode" File="psqlodbc35w.dll" />
+		  <RegistryValue Id="psqlodbc30a.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="CPTimeout" Type="string" Value="60" />
+		  <RegistryValue Id="psqlodbc35w.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="CPTimeout" Type="string" Value="60" />
+		  <RegistryValue Id="psqlodbc30a.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI($(var.Platform))" Name="CPTimeout" Type="string" Value="60" />
+		  <RegistryValue Id="psqlodbc35w.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode($(var.Platform))" Name="CPTimeout" Type="string" Value="60" />
 <?else?>
-          <RegistryValue Id="psqlodbc30a.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers" Name="PostgreSQL ANSI" Type="string" Value="Installed" />
-          <RegistryValue Id="psqlodbc30a.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="APILevel" Type="string" Value="1" />
-          <RegistryValue Id="psqlodbc30a.reg.3" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="ConnectFunctions" Type="string" Value="YYN" />
-          <RegistryValue Id="psqlodbc30a.reg.4" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="Driver" Type="string" Value="[#psqlodbc30a.dll]" />
-          <RegistryValue Id="psqlodbc30a.reg.5" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="DriverODBCVer" Type="string" Value="03.50" />
-          <RegistryValue Id="psqlodbc30a.reg.6" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="FileUsage" Type="string" Value="0" />
-          <RegistryValue Id="psqlodbc30a.reg.7" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="Setup" Type="string" Value="[#psqlodbc30a.dll]" />
-          <RegistryValue Id="psqlodbc30a.reg.8" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="SQLLevel" Type="string" Value="1" />
-          <RegistryValue Id="psqlodbc30a.reg.9" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="UsageCount" Type="integer" Value="1" />
-          <RegistryValue Id="psqlodbc30a.reg.10" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="CPTimeout" Type="string" Value="60" />
+		  <RegistryValue Id="psqlodbc30a.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers" Name="PostgreSQL ANSI" Type="string" Value="Installed" />
+		  <RegistryValue Id="psqlodbc30a.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="APILevel" Type="string" Value="1" />
+		  <RegistryValue Id="psqlodbc30a.reg.3" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="ConnectFunctions" Type="string" Value="YYN" />
+		  <RegistryValue Id="psqlodbc30a.reg.4" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="Driver" Type="string" Value="[#psqlodbc30a.dll]" />
+		  <RegistryValue Id="psqlodbc30a.reg.5" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="DriverODBCVer" Type="string" Value="03.50" />
+		  <RegistryValue Id="psqlodbc30a.reg.6" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="FileUsage" Type="string" Value="0" />
+		  <RegistryValue Id="psqlodbc30a.reg.7" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="Setup" Type="string" Value="[#psqlodbc30a.dll]" />
+		  <RegistryValue Id="psqlodbc30a.reg.8" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="SQLLevel" Type="string" Value="1" />
+		  <RegistryValue Id="psqlodbc30a.reg.9" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="UsageCount" Type="integer" Value="1" />
+		  <RegistryValue Id="psqlodbc30a.reg.10" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="CPTimeout" Type="string" Value="60" />
 
-          <RegistryValue Id="psqlodbc35w.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers" Name="PostgreSQL Unicode" Type="string" Value="Installed" />
-          <RegistryValue Id="psqlodbc35w.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="APILevel" Type="string" Value="1" />
-          <RegistryValue Id="psqlodbc35w.reg.3" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="ConnectFunctions" Type="string" Value="YYN" />
-          <RegistryValue Id="psqlodbc35w.reg.4" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="Driver" Type="string" Value="[#psqlodbc35w.dll]" />
-          <RegistryValue Id="psqlodbc35w.reg.5" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="DriverODBCVer" Type="string" Value="03.51" />
-          <RegistryValue Id="psqlodbc35w.reg.6" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="FileUsage" Type="string" Value="0" />
-          <RegistryValue Id="psqlodbc35w.reg.7" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="Setup" Type="string" Value="[#psqlodbc35w.dll]" />
-          <RegistryValue Id="psqlodbc35w.reg.8" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="SQLLevel" Type="string" Value="1" />
-          <RegistryValue Id="psqlodbc35w.reg.9" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="UsageCount" Type="integer" Value="1" />
-          <RegistryValue Id="psqlodbc35w.reg.10" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="CPTimeout" Type="string" Value="60" />
+		  <RegistryValue Id="psqlodbc35w.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers" Name="PostgreSQL Unicode" Type="string" Value="Installed" />
+		  <RegistryValue Id="psqlodbc35w.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="APILevel" Type="string" Value="1" />
+		  <RegistryValue Id="psqlodbc35w.reg.3" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="ConnectFunctions" Type="string" Value="YYN" />
+		  <RegistryValue Id="psqlodbc35w.reg.4" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="Driver" Type="string" Value="[#psqlodbc35w.dll]" />
+		  <RegistryValue Id="psqlodbc35w.reg.5" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="DriverODBCVer" Type="string" Value="03.51" />
+		  <RegistryValue Id="psqlodbc35w.reg.6" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="FileUsage" Type="string" Value="0" />
+		  <RegistryValue Id="psqlodbc35w.reg.7" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="Setup" Type="string" Value="[#psqlodbc35w.dll]" />
+		  <RegistryValue Id="psqlodbc35w.reg.8" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="SQLLevel" Type="string" Value="1" />
+		  <RegistryValue Id="psqlodbc35w.reg.9" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="UsageCount" Type="integer" Value="1" />
+		  <RegistryValue Id="psqlodbc35w.reg.10" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="CPTimeout" Type="string" Value="60" />
 <?endif?>
-        </Component>
+		</Component>
 	<!--
 		MSDTC runs in 64bit mode on 64bit machines and 32bit mode on
 		32bit machines. We had better register the XA DLL on 
 		installation.
 	--> 
-        <Component Id="pgxalib.files" Guid="$(var.CIDXFILES)" Win64="$(var.BIT64)">
-<?if $(var.BIT64) = no ?>
-	  <Condition>
-	    <![CDATA[NOT VersionNT64]]>
-	  </Condition>
-<?endif?>
-          <File Id="pgxalib.dll" Name="pgxalib.dll" Source="$(var.BINBASE)/$(var.UNICODEFOLDER)/pgxalib.dll" />
-          <RegistryValue Id="pgxalib.reg.1" Root="HKLM" Key="SOFTWARE\Microsoft\MSDTC\XADLL" Name="pgxalib.dll" Type="string" Value="[#pgxalib.dll]" />
-	</Component>
-      </Directory>
+		<Component Id="pgxalib.files" Win64="$(var.BIT64)">
+	<?if $(var.BIT64) = no ?>	<!-- On x64 OS only install from x64 package. -->
+		  <Condition>
+			<![CDATA[NOT VersionNT64]]>
+		  </Condition>
+	<?endif?>
+		  <File Name="pgxalib.dll" Source="$(var.BINBASE)/$(var.UNICODEFOLDER)/pgxalib.dll" />
+		  <RegistryValue Id="pgxalib.reg.1" Root="HKLM" Key="SOFTWARE\Microsoft\MSDTC\XADLL" Name="pgxalib.dll" Type="string" Value="[#pgxalib.dll]" />
+		</Component>
+	  </Directory>
     </Directory>
 
   </Module>

--- a/installer/psqlodbcm_cpu.wxs
+++ b/installer/psqlodbcm_cpu.wxs
@@ -72,7 +72,14 @@
       <Directory Id="BINDIR" Name="." ComponentGuidGenerationSeed="495CEE94-BDB9-4309-9544-D98783259CD8">
 		<!-- PostgreSQL -->
 		<Component Id="psqlodbc.psqlodbc30a.dll" Win64="$(var.BIT64)">
-		  <File Name="psqlodbc30a.dll" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\psqlodbc30a.dll" />
+		  <File Name="psqlodbc30a.dll" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\psqlodbc30a.dll">
+			<ODBCDriver Id="Psqlodbc_9.0_Driver_ANSI" Name="PostgreSQL ANSI($(var.Platform))">
+				<Property Id="CPTimeout" Value="60"/>
+			</ODBCDriver>
+			<ODBCDriver Id="Psqlodbc_11_newid_Driver_ANSI" Name="PostgreSQL ANSI">
+				<Property Id="CPTimeout" Value="60"/>
+			</ODBCDriver>
+		  </File>
 		</Component>
 		<Component Id="psqlodbc.pgenlista.dll" Win64="$(var.BIT64)">
 		  <File Name="pgenlista.dll" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\pgenlista.dll" />
@@ -86,7 +93,14 @@
 		</Component>
 <?endif?>
 		<Component Id="psqlodbc.psqlodbc35w.dll" Win64="$(var.BIT64)">
-		  <File Name="psqlodbc35w.dll" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\psqlodbc35w.dll" />
+		  <File Name="psqlodbc35w.dll" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\psqlodbc35w.dll">
+			<ODBCDriver Id="Psqlodbc_9.0_Driver" Name="PostgreSQL Unicode($(var.Platform))">
+				<Property Id="CPTimeout" Value="60"/>
+			</ODBCDriver>
+			<ODBCDriver Id="Psqlodbc_11_newid_Driver" Name="PostgreSQL Unicode">
+				<Property Id="CPTimeout" Value="60"/>
+			</ODBCDriver>
+		  </File>
 		</Component>
 		<Component Id="psqlodbc.pgenlist.dll" Win64="$(var.BIT64)">
 		  <File Name="pgenlist.dll" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\pgenlist.dll" />
@@ -193,17 +207,9 @@
 			   works. Nowadays, it probably would be safe to use ODBCDriver on
 			   all platforms, but no-one's gotten around to revisit this
 		  -->
-		<Component Id="psqlodbc.odbcdriver" Win64="$(var.BIT64)">
-<?if $(var.Platform) = x64 ?>
-		  <ODBCDriver Id="Psqlodbc_9.0_Driver_ANSI" Name="PostgreSQL ANSI($(var.Platform))" File="psqlodbc30a.dll" />
-		  <ODBCDriver Id="Psqlodbc_9.0_Driver" Name="PostgreSQL Unicode($(var.Platform))" File="psqlodbc35w.dll" />
-		  <ODBCDriver Id="Psqlodbc_11_newid_Driver_ANSI" Name="PostgreSQL ANSI" File="psqlodbc30a.dll" />
-		  <ODBCDriver Id="Psqlodbc_11_newid_Driver" Name="PostgreSQL Unicode" File="psqlodbc35w.dll" />
-		  <RegistryValue Id="psqlodbc30a.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="CPTimeout" Type="string" Value="60" />
-		  <RegistryValue Id="psqlodbc35w.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="CPTimeout" Type="string" Value="60" />
-		  <RegistryValue Id="psqlodbc30a.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI($(var.Platform))" Name="CPTimeout" Type="string" Value="60" />
-		  <RegistryValue Id="psqlodbc35w.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode($(var.Platform))" Name="CPTimeout" Type="string" Value="60" />
-<?else?>
+<?if $(var.Platform) != x64 ?>
+		<!-- The component GUID below must change whenever any of the Registry data changes. -->
+		<Component Id="psqlodbc.odbcdriver" Guid="08041331-CA67-4DE5-BA93-EBBC93F3687C" Win64="$(var.BIT64)">
 		  <RegistryValue Id="psqlodbc30a.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers" Name="PostgreSQL ANSI" Type="string" Value="Installed" />
 		  <RegistryValue Id="psqlodbc30a.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="APILevel" Type="string" Value="1" />
 		  <RegistryValue Id="psqlodbc30a.reg.3" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="ConnectFunctions" Type="string" Value="YYN" />
@@ -225,8 +231,9 @@
 		  <RegistryValue Id="psqlodbc35w.reg.8" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="SQLLevel" Type="string" Value="1" />
 		  <RegistryValue Id="psqlodbc35w.reg.9" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="UsageCount" Type="integer" Value="1" />
 		  <RegistryValue Id="psqlodbc35w.reg.10" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="CPTimeout" Type="string" Value="60" />
-<?endif?>
 		</Component>
+<?endif?>
+
 	<!--
 		MSDTC runs in 64bit mode on 64bit machines and 32bit mode on
 		32bit machines. We had better register the XA DLL on 

--- a/installer/psqlodbcm_cpu.wxs
+++ b/installer/psqlodbcm_cpu.wxs
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 
-<!-- Default to x86 platform -->
-<?ifndef var.Platform ?>
-  <?define Platform = "x86" ?>
-<?else?>
-  <?if $(var.Platform) != x64 and $(var.Platform) != x86 ?>
-    <?error Invalid Platform variable ?>
-  <?endif?>
-<?endif?>
-
 <?ifndef var.BINBASE ?>
   <?define BINBASE = ".." ?>
 <?endif?>
 
-<?if $(var.Platform) = x64 ?>
-  <?define ModuleName = "psqlODBC_$(var.Platform)" ?>
+<?if $(sys.BUILDARCH) = x64 ?>
+  <?define Platform = "x64" ?>
+  <?define ModuleName = "psqlODBC_x64" ?>
   <?define BIT64 = "yes" ?>
   <?define ANSIFOLDER = "x64_ANSI_Release" ?>
   <?define UNICODEFOLDER = "x64_Unicode_Release" ?>
@@ -26,7 +18,8 @@
 <?else?>
   <?define SysFolder = "$(env.SystemRoot)\sysnative" ?>
 <?endif?>
-<?else?>
+<?elseif $(sys.BUILDARCH) = x86 ?>
+  <?define Platform = "x86" ?>
   <?define ModuleName = "psqlODBC" ?>
   <?define BIT64 = "no" ?>
   <?define ANSIFOLDER = "x86_ANSI_Release" ?>
@@ -38,6 +31,8 @@
 <?else?>
   <?define SysFolder = "$(env.SystemRoot)\system32" ?>
 <?endif?>
+<?else?>	<!-- sys.BUILDARCH -->
+  <?error Invalid build architecture ?>
 <?endif?>
 
   <Module
@@ -51,7 +46,6 @@
       Keywords="PostgreSQL, ODBC"
       Manufacturer="PostgreSQL Global Development Group"
       InstallerVersion="$(var.InstallerVersion)"
-      Platform="$(var.Platform)"
       Languages="1033"
       SummaryCodepage="1252" />
 
@@ -71,7 +65,7 @@
 		-->
       <Directory Id="BINDIR" Name="." ComponentGuidGenerationSeed="495CEE94-BDB9-4309-9544-D98783259CD8">
 		<!-- PostgreSQL -->
-		<Component Id="psqlodbc.psqlodbc30a.dll" Win64="$(var.BIT64)">
+		<Component Id="psqlodbc.psqlodbc30a.dll">
 		  <File Name="psqlodbc30a.dll" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\psqlodbc30a.dll">
 			<ODBCDriver Id="Psqlodbc_9.0_Driver_ANSI" Name="PostgreSQL ANSI($(var.Platform))">
 				<Property Id="CPTimeout" Value="60"/>
@@ -81,18 +75,18 @@
 			</ODBCDriver>
 		  </File>
 		</Component>
-		<Component Id="psqlodbc.pgenlista.dll" Win64="$(var.BIT64)">
+		<Component Id="psqlodbc.pgenlista.dll">
 		  <File Name="pgenlista.dll" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\pgenlista.dll" />
 		</Component>
 <?if $(var.NoPDB) != True ?>
-		<Component Id="psqlodbc.psqlodbc30a.pdb" Win64="$(var.BIT64)">
+		<Component Id="psqlodbc.psqlodbc30a.pdb">
 		  <File Name="psqlodbc30a.pdb" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\psqlodbc30a.pdb" />
 		</Component>
-		<Component Id="psqlodbc.pgenlista.pdb" Win64="$(var.BIT64)">
+		<Component Id="psqlodbc.pgenlista.pdb">
 		  <File Name="pgenlista.pdb" Source="$(var.BINBASE)\$(var.ANSIFOLDER)\pgenlista.pdb" />
 		</Component>
 <?endif?>
-		<Component Id="psqlodbc.psqlodbc35w.dll" Win64="$(var.BIT64)">
+		<Component Id="psqlodbc.psqlodbc35w.dll">
 		  <File Name="psqlodbc35w.dll" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\psqlodbc35w.dll">
 			<ODBCDriver Id="Psqlodbc_9.0_Driver" Name="PostgreSQL Unicode($(var.Platform))">
 				<Property Id="CPTimeout" Value="60"/>
@@ -102,101 +96,101 @@
 			</ODBCDriver>
 		  </File>
 		</Component>
-		<Component Id="psqlodbc.pgenlist.dll" Win64="$(var.BIT64)">
+		<Component Id="psqlodbc.pgenlist.dll">
 		  <File Name="pgenlist.dll" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\pgenlist.dll" />
 		</Component>
 <?if $(var.NoPDB) != True ?>
-		<Component Id="psqlodbc.psqlodbc35w.pdb" Win64="$(var.BIT64)">
+		<Component Id="psqlodbc.psqlodbc35w.pdb">
 		  <File Name="psqlodbc35w.pdb" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\psqlodbc35w.pdb" />
 		</Component>
-		<Component Id="psqlodbc.pgenlist.pdb" Win64="$(var.BIT64)">
+		<Component Id="psqlodbc.pgenlist.pdb">
 		  <File Name="pgenlist.pdb" Source="$(var.BINBASE)\$(var.UNICODEFOLDER)\pgenlist.pdb" />
 		</Component>
 <?endif?>
 
 		<!-- MSVC Runtime -->
 <?if "$(var.PODBCMSVCDLL)" != "" ?>
-		<Component Id="vcredist.vcruntime.dll.psqlodbc" Win64="$(var.BIT64)">
+		<Component Id="vcredist.vcruntime.dll.psqlodbc">
 		  <File Source="$(var.PODBCMSVCDLL)" />
 		</Component>
 <?endif?>
 <?if "$(var.PODBCMSVPDLL)" != "" ?>
-		<Component Id="vcredist.msvcp.dll.psqlodbc" Win64="$(var.BIT64)">
+		<Component Id="vcredist.msvcp.dll.psqlodbc">
 		  <File Source="$(var.PODBCMSVPDLL)" />
 		</Component>
 <?endif?>
 <?if "$(var.PODBCMSVCSYS)" != "" ?>
-		<Component Id="system.vcruntime.dll.psqlodbc" Win64="$(var.BIT64)">
+		<Component Id="system.vcruntime.dll.psqlodbc">
 		  <File Source="$(var.SysFolder)\$(var.PODBCMSVCSYS)" />
 		</Component>
 <?endif?>
 <?if "$(var.PODBCMSVPSYS)" != "" ?>
-		<Component Id="system.msvcp.dll.psqlodbc" Win64="$(var.BIT64)">
+		<Component Id="system.msvcp.dll.psqlodbc">
 		  <File Source="$(var.SysFolder)\$(var.PODBCMSVPSYS)" />
 		</Component>
 <?endif?>
 <?if "$(var.LIBPQMSVCDLL)" != "" ?>
-		<Component Id="vcredist.vcruntime.dll.libpq" Win64="$(var.BIT64)">
+		<Component Id="vcredist.vcruntime.dll.libpq">
 		  <File Source="$(var.LIBPQMSVCDLL)" />
 		</Component>
 <?endif?>
 <?if "$(var.LIBPQMSVCSYS)" != "" ?>
-		<Component Id="system.vcruntime.dll.libpq" Win64="$(var.BIT64)">
+		<Component Id="system.vcruntime.dll.libpq">
 		  <File Source="$(var.SysFolder)\$(var.LIBPQMSVCSYS)" />
 		</Component>
 <?endif?>
 
 		<!-- libpq -->
-		<Component Id="libpq.libpq.dll" Win64="$(var.BIT64)">
+		<Component Id="libpq.libpq.dll">
 		  <File Id="libpq.dll" Name="libpq.dll" Source="$(var.LIBPQBINDIR)\libpq.dll" />
 		</Component>
 <?if "$(var.LIBPQMEM0)" != "" ?>
-		<Component Id="libpq.related0.dll" Win64="$(var.BIT64)">
+		<Component Id="libpq.related0.dll">
 		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM0)" />
 		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM1)" != "" ?>
-		<Component Id="libpq.related1.dll" Win64="$(var.BIT64)">
+		<Component Id="libpq.related1.dll">
 		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM1)" />
 		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM2)" != "" ?>
-		<Component Id="libpq.related2.dll" Win64="$(var.BIT64)">
+		<Component Id="libpq.related2.dll">
 		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM2)" />
 		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM3)" != "" ?>
-		<Component Id="libpq.related3.dll" Win64="$(var.BIT64)">
+		<Component Id="libpq.related3.dll">
 		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM3)" />
 		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM4)" != "" ?>
-		<Component Id="libpq.related4.dll" Win64="$(var.BIT64)">
+		<Component Id="libpq.related4.dll">
 		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM4)" />
 		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM5)" != "" ?>
-		<Component Id="libpq.related5.dll" Win64="$(var.BIT64)">
+		<Component Id="libpq.related5.dll">
 		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM5)" />
 		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM6)" != "" ?>
-		<Component Id="libpq.related6.dll" Win64="$(var.BIT64)">
+		<Component Id="libpq.related6.dll">
 		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM6)" />
 		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM7)" != "" ?>
-		<Component Id="libpq.related7.dll" Win64="$(var.BIT64)">
+		<Component Id="libpq.related7.dll">
 		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM7)" />
 		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM8)" != "" ?>
-		<Component Id="libpq.related8.dll" Win64="$(var.BIT64)">
+		<Component Id="libpq.related8.dll">
 		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM8)" />
 		</Component>
 <?endif ?>
 <?if "$(var.LIBPQMEM9)" != "" ?>
-		<Component Id="libpq.related9.dll" Win64="$(var.BIT64)">
+		<Component Id="libpq.related9.dll">
 		  <File Source="$(var.LIBPQBINDIR)\$(var.LIBPQMEM9)" />
 		</Component>
 <?endif ?>
@@ -206,7 +200,7 @@
 		32bit machines. We had better register the XA DLL on 
 		installation.
 	--> 
-		<Component Id="pgxalib.files" Win64="$(var.BIT64)">
+		<Component Id="pgxalib.files">
 	<?if $(var.BIT64) = no ?>	<!-- On x64 OS only install from x64 package. -->
 		  <Condition>
 			<![CDATA[NOT VersionNT64]]>

--- a/installer/psqlodbcm_cpu.wxs
+++ b/installer/psqlodbcm_cpu.wxs
@@ -201,39 +201,6 @@
 		</Component>
 <?endif ?>
 
-		  <!-- Note, installing the driver properly (IE, using ODBCDriver) has
-			   proven unreliable, so we install the registry keys manually
-			   ourselves. On 64-bit Windows, however, we trust that ODBCDriver
-			   works. Nowadays, it probably would be safe to use ODBCDriver on
-			   all platforms, but no-one's gotten around to revisit this
-		  -->
-<?if $(var.Platform) != x64 ?>
-		<!-- The component GUID below must change whenever any of the Registry data changes. -->
-		<Component Id="psqlodbc.odbcdriver" Guid="08041331-CA67-4DE5-BA93-EBBC93F3687C" Win64="$(var.BIT64)">
-		  <RegistryValue Id="psqlodbc30a.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers" Name="PostgreSQL ANSI" Type="string" Value="Installed" />
-		  <RegistryValue Id="psqlodbc30a.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="APILevel" Type="string" Value="1" />
-		  <RegistryValue Id="psqlodbc30a.reg.3" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="ConnectFunctions" Type="string" Value="YYN" />
-		  <RegistryValue Id="psqlodbc30a.reg.4" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="Driver" Type="string" Value="[#psqlodbc30a.dll]" />
-		  <RegistryValue Id="psqlodbc30a.reg.5" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="DriverODBCVer" Type="string" Value="03.50" />
-		  <RegistryValue Id="psqlodbc30a.reg.6" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="FileUsage" Type="string" Value="0" />
-		  <RegistryValue Id="psqlodbc30a.reg.7" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="Setup" Type="string" Value="[#psqlodbc30a.dll]" />
-		  <RegistryValue Id="psqlodbc30a.reg.8" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="SQLLevel" Type="string" Value="1" />
-		  <RegistryValue Id="psqlodbc30a.reg.9" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="UsageCount" Type="integer" Value="1" />
-		  <RegistryValue Id="psqlodbc30a.reg.10" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL ANSI" Name="CPTimeout" Type="string" Value="60" />
-
-		  <RegistryValue Id="psqlodbc35w.reg.1" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers" Name="PostgreSQL Unicode" Type="string" Value="Installed" />
-		  <RegistryValue Id="psqlodbc35w.reg.2" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="APILevel" Type="string" Value="1" />
-		  <RegistryValue Id="psqlodbc35w.reg.3" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="ConnectFunctions" Type="string" Value="YYN" />
-		  <RegistryValue Id="psqlodbc35w.reg.4" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="Driver" Type="string" Value="[#psqlodbc35w.dll]" />
-		  <RegistryValue Id="psqlodbc35w.reg.5" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="DriverODBCVer" Type="string" Value="03.51" />
-		  <RegistryValue Id="psqlodbc35w.reg.6" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="FileUsage" Type="string" Value="0" />
-		  <RegistryValue Id="psqlodbc35w.reg.7" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="Setup" Type="string" Value="[#psqlodbc35w.dll]" />
-		  <RegistryValue Id="psqlodbc35w.reg.8" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="SQLLevel" Type="string" Value="1" />
-		  <RegistryValue Id="psqlodbc35w.reg.9" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="UsageCount" Type="integer" Value="1" />
-		  <RegistryValue Id="psqlodbc35w.reg.10" Root="HKLM" Key="SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode" Name="CPTimeout" Type="string" Value="60" />
-		</Component>
-<?endif?>
-
 	<!--
 		MSDTC runs in 64bit mode on 64bit machines and 32bit mode on
 		32bit machines. We had better register the XA DLL on 


### PR DESCRIPTION
This is the yield from ~8 hours of poring over the code. This is mostly janitorial stuff, but I'm by no means done; there is more to come. It would be great if you could look it over and tell me whether you are comfortable with it.

My claim in #57 that the component rules violation was the reason for the installation path not changing between versions was wrong. This is in fact an intentional behavior of Windows Installer as long as ODBC drivers are installed using the built-in support, i.e. the ODBCDriver table. In that case, the SetODBCFolders standard action overrides the installation path to maintain the driver in the same location.