### PR TITLE
Fix typo failing the Rebuild target

### DIFF
--- a/winbuild/platformbuild.vcxproj
+++ b/winbuild/platformbuild.vcxproj
@@ -103,7 +103,7 @@
 		Condition="!exists('$(PG_BIN)')"/>
 	<Error
 	  Text="$(PG_BIN)\libpq.dll doesn't exist.%0D%0Aset PG_BIN properly."
-		Condition="!exists('$(PG_BIN)\llibpq.dll')"/>
+		Condition="!exists('$(PG_BIN)\libpq.dll')"/>
         <MSBuild Projects="psqlsetup.vcxproj"
 	  Targets="ReBuild"
 	  Properties="Configuration=$(Configuration);srcPath=$(srcPath)"/>


### PR DESCRIPTION
`BuildAll.ps1 -Target Rebuild` always reports an error that libpq.dll does not exist, caused by a typo in the error condition.