### PR TITLE
Fix PG_ErrorInfo and ER_ReturnError when error message is larger than 65535 bytes

### DIFF
--- a/psqlodbc.h
+++ b/psqlodbc.h
@@ -614,12 +614,11 @@ typedef struct QueryInfo_
 typedef struct
 {
         UInt4	status;
-        Int2	errorsize;
-        Int2	recsize;
-        Int2	errorpos;
+		UInt4	errsize;
+        UInt4	errpos;
+        UInt2	recsize;
         char    sqlstate[6];
-        SQLLEN	diag_row_count;
-        char    __error_message[40];
+        char    __error_message[44];
 }       PG_ErrorInfo;
 PG_ErrorInfo	*ER_Constructor(SDWORD errornumber, const char *errormsg);
 PG_ErrorInfo	*ER_Dup(const PG_ErrorInfo *from);

--- a/statement.c
+++ b/statement.c
@@ -1409,9 +1409,8 @@ SC_create_errorinfo(const StatementClass *self, PG_ErrorInfo *pgerror_fail_safe)
 			memset(pgerror_fail_safe, 0, sizeof(*pgerror_fail_safe));
 			pgerror = pgerror_fail_safe;
 			pgerror->status = self->__error_number;
-			pgerror->errorsize = sizeof(pgerror->__error_message);
 			STRCPY_FIXED(pgerror->__error_message, ermsg);
-			pgerror->recsize = -1;
+			pgerror->errsize = strlen(pgerror->__error_message);
 		}
 		else
 			return NULL;


### PR DESCRIPTION
Old driver truncated the server error message incorrectly.

## old implementation 
environ.c:147:
```c
error->errorsize = (Int2) errsize;
```
When `errsize` is larger than 32767, the errorsize is wrong.

environ.c:204:
```c
msglen = (SQLSMALLINT) strlen(msg);
```
`msglen` is truncated when msg is larger than 65535 bytes.

environ.c:224:
```c
RecNumber = 2 + (error->errorpos - 1) / error->recsize;
```
`errorpos` is used but never set.

## new implementaion
In `PG_ErrorInfo`, makes `errsize`, `errpos` UInt4.
```c
typedef struct
{
        UInt4	status;
	UInt4	errsize;
        UInt4	errpos;
        UInt2	recsize;
        char    sqlstate[6];
        char    __error_message[44];
}       PG_ErrorInfo;
```
Fix `ER_Construct` and `ER_Dup` .
In `ER_ReturnError`, makes `msglen`, `wrtlen`, `pcblen` UInt4, and set `errpos` correctly.
```c
UInt4		stapos, msglen, wrtlen, pcblen;
```
```c
msglen = error->errsize;
```
```c
error->errpos = stapos + wrtlen;
```
