### PR TITLE
chore: replace unsafe string-to-number conversions

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -778,7 +778,7 @@ CC_set_translation(ConnectionClass *self)
 	if (self->connInfo.translation_dll[0] == 0)
 		return TRUE;
 
-	self->translation_option = atoi(self->connInfo.translation_option);
+	self->translation_option = pg_atoi(self->connInfo.translation_option);
 	self->translation_handle = LoadLibrary(self->connInfo.translation_dll);
 
 	if (self->translation_handle == NULL)
@@ -2082,7 +2082,7 @@ MYLOG(DETAIL_LOG_LEVEL, "Discarded a RELEASE result\n");
 				{
 					ptr = strrchr(cmdbuffer, ' ');
 					if (ptr)
-						res->recent_processed_row_count = atoi(ptr + 1);
+						res->recent_processed_row_count = pg_atoi(ptr + 1);
 					else
 						res->recent_processed_row_count = -1;
 					if (self->current_schema_valid &&

--- a/connection.h
+++ b/connection.h
@@ -222,11 +222,11 @@ do { \
  *		  It must be a decimal constant of the form %d.%d .
  */
 #define PG_VERSION_GT(conn, ver) \
- (SERVER_VERSION_GT(conn, (int) ver, atoi(STRING_AFTER_DOT(ver))))
+ (SERVER_VERSION_GT(conn, (int) ver, pg_atoi(STRING_AFTER_DOT(ver))))
 #define PG_VERSION_GE(conn, ver) \
- (SERVER_VERSION_GE(conn, (int) ver, atoi(STRING_AFTER_DOT(ver))))
+ (SERVER_VERSION_GE(conn, (int) ver, pg_atoi(STRING_AFTER_DOT(ver))))
 #define PG_VERSION_EQ(conn, ver) \
- (SERVER_VERSION_EQ(conn, (int) ver, atoi(STRING_AFTER_DOT(ver))))
+ (SERVER_VERSION_EQ(conn, (int) ver, pg_atoi(STRING_AFTER_DOT(ver))))
 #define PG_VERSION_LE(conn, ver) (! PG_VERSION_GT(conn, ver))
 #define PG_VERSION_LT(conn, ver) (! PG_VERSION_GE(conn, ver))
 

--- a/convert.c
+++ b/convert.c
@@ -235,7 +235,7 @@ static SQLLEN pg_bin2whex(const char *src, SQLWCHAR *dst, SQLLEN length);
 #elif	defined(HAVE_STRTOUL)
 #define	ATOI32U(val)	strtoul(val, NULL, 10)
 #else /* HAVE_STRTOUL */
-#define	ATOI32U	atol
+#define	ATOI32U(val)	strtol(val, NULL, 10)
 #endif /* WIN32 */
 
 /*
@@ -334,23 +334,23 @@ timestamp2stime(const char *str, SIMPLE_TIME *st, BOOL *bZone, int *zone)
 	{
 		case '+':
 			*bZone = TRUE;
-			*zone = atoi(&rest[1]);
+			*zone = pg_atoi(&rest[1]);
 			break;
 		case '-':
 			*bZone = TRUE;
-			*zone = -atoi(&rest[1]);
+			*zone = -pg_atoi(&rest[1]);
 			break;
 		case '.':
 			if ((ptr = strchr(rest, '+')) != NULL)
 			{
 				*bZone = TRUE;
-				*zone = atoi(&ptr[1]);
+				*zone = pg_atoi(&ptr[1]);
 				*ptr = '\0';
 			}
 			else if ((ptr = strchr(rest, '-')) != NULL)
 			{
 				*bZone = TRUE;
-				*zone = -atoi(&ptr[1]);
+				*zone = -pg_atoi(&ptr[1]);
 				*ptr = '\0';
 			}
 			for (i = 1; i < 10; i++)
@@ -361,7 +361,7 @@ timestamp2stime(const char *str, SIMPLE_TIME *st, BOOL *bZone, int *zone)
 			for (; i < 10; i++)
 				rest[i] = '0';
 			rest[i] = '\0';
-			st->fr = atoi(&rest[1]);
+			st->fr = pg_atoi(&rest[1]);
 			break;
 		case 'B':
 			if (stricmp(rest, "BC") == 0)
@@ -563,7 +563,7 @@ static int getPrecisionPart(int precision, const char * precPart)
 	memcpy(fraction, precPart, cpys);
 	fraction[precision] = '\0';
 
-	return atoi(fraction);
+	return pg_atoi(fraction);
 }
 
 static BOOL
@@ -849,7 +849,7 @@ static double get_double_value(const char *str)
 #else
 		return (double) -(HUGE_VAL * HUGE_VAL);
 #endif /* INFINITY */
-	return atof(str);
+	return pg_atof(str);
 }
 
 static int char2guid(const char *str, SQLGUID *g)
@@ -1802,29 +1802,29 @@ MYLOG(DETAIL_LOG_LEVEL, "2stime fr=%d\n", std_time.fr);
 			case SQL_C_BIT:
 				len = 1;
 				if (bind_size > 0)
-					*((UCHAR *) rgbValueBindRow) = atoi(neut_str);
+					*((UCHAR *) rgbValueBindRow) = pg_atoi(neut_str);
 				else
-					*((UCHAR *) rgbValue + bind_row) = atoi(neut_str);
+					*((UCHAR *) rgbValue + bind_row) = pg_atoi(neut_str);
 
 				 MYLOG(99, "SQL_C_BIT: bind_row = " FORMAT_POSIROW " val = %d, cb = " FORMAT_LEN ", rgb=%d\n",
-					bind_row, atoi(neut_str), cbValueMax, *((UCHAR *)rgbValue));
+					bind_row, pg_atoi(neut_str), cbValueMax, *((UCHAR *)rgbValue));
 				break;
 
 			case SQL_C_STINYINT:
 			case SQL_C_TINYINT:
 				len = 1;
 				if (bind_size > 0)
-					*((SCHAR *) rgbValueBindRow) = atoi(neut_str);
+					*((SCHAR *) rgbValueBindRow) = pg_atoi(neut_str);
 				else
-					*((SCHAR *) rgbValue + bind_row) = atoi(neut_str);
+					*((SCHAR *) rgbValue + bind_row) = pg_atoi(neut_str);
 				break;
 
 			case SQL_C_UTINYINT:
 				len = 1;
 				if (bind_size > 0)
-					*((UCHAR *) rgbValueBindRow) = atoi(neut_str);
+					*((UCHAR *) rgbValueBindRow) = pg_atoi(neut_str);
 				else
-					*((UCHAR *) rgbValue + bind_row) = atoi(neut_str);
+					*((UCHAR *) rgbValue + bind_row) = pg_atoi(neut_str);
 				break;
 
 			case SQL_C_FLOAT:
@@ -1865,26 +1865,26 @@ MYLOG(DETAIL_LOG_LEVEL, "2stime fr=%d\n", std_time.fr);
 			case SQL_C_SHORT:
 				len = 2;
 				if (bind_size > 0)
-					*((SQLSMALLINT *) rgbValueBindRow) = atoi(neut_str);
+					*((SQLSMALLINT *) rgbValueBindRow) = pg_atoi(neut_str);
 				else
-					*((SQLSMALLINT *) rgbValue + bind_row) = atoi(neut_str);
+					*((SQLSMALLINT *) rgbValue + bind_row) = pg_atoi(neut_str);
 				break;
 
 			case SQL_C_USHORT:
 				len = 2;
 				if (bind_size > 0)
-					*((SQLUSMALLINT *) rgbValueBindRow) = atoi(neut_str);
+					*((SQLUSMALLINT *) rgbValueBindRow) = pg_atoi(neut_str);
 				else
-					*((SQLUSMALLINT *) rgbValue + bind_row) = atoi(neut_str);
+					*((SQLUSMALLINT *) rgbValue + bind_row) = pg_atoi(neut_str);
 				break;
 
 			case SQL_C_SLONG:
 			case SQL_C_LONG:
 				len = 4;
 				if (bind_size > 0)
-					*((SQLINTEGER *) rgbValueBindRow) = atol(neut_str);
+					*((SQLINTEGER *) rgbValueBindRow) = pg_atol(neut_str);
 				else
-					*((SQLINTEGER *) rgbValue + bind_row) = atol(neut_str);
+					*((SQLINTEGER *) rgbValue + bind_row) = pg_atol(neut_str);
 				break;
 
 			case SQL_C_ULONG:

--- a/dlg_specific.c
+++ b/dlg_specific.c
@@ -653,7 +653,7 @@ copyConnAttributes(ConnInfo *ci, const char *attribute, const char *value)
 				*ptr = '\0';
 				/* ignore first part */
 			}
-			ci->rollback_on_error = atoi(ptr + 1);
+			ci->rollback_on_error = pg_atoi(ptr + 1);
 			MYLOG(0, "key='%s' value='%s' rollback_on_error=%d\n",
 				attribute, value, ci->rollback_on_error);
 			printed = TRUE;
@@ -681,31 +681,31 @@ copyConnAttributes(ConnInfo *ci, const char *attribute, const char *value)
 		ci->pqopt = decode_or_remove_braces(value);
 	}
 	else if (stricmp(attribute, INI_UPDATABLECURSORS) == 0 || stricmp(attribute, ABBR_UPDATABLECURSORS) == 0)
-		ci->allow_keyset = atoi(value);
+		ci->allow_keyset = pg_atoi(value);
 	else if (stricmp(attribute, INI_LFCONVERSION) == 0 || stricmp(attribute, ABBR_LFCONVERSION) == 0)
-		ci->lf_conversion = atoi(value);
+		ci->lf_conversion = pg_atoi(value);
 	else if (stricmp(attribute, INI_TRUEISMINUS1) == 0 || stricmp(attribute, ABBR_TRUEISMINUS1) == 0)
-		ci->true_is_minus1 = atoi(value);
+		ci->true_is_minus1 = pg_atoi(value);
 	else if (stricmp(attribute, INI_INT8AS) == 0)
-		ci->int8_as = atoi(value);
+		ci->int8_as = pg_atoi(value);
 	else if (stricmp(attribute, INI_NUMERIC_AS) == 0 || stricmp(attribute, ABBR_NUMERIC_AS) == 0)
-		ci->numeric_as = atoi(value);
+		ci->numeric_as = pg_atoi(value);
 	else if (stricmp(attribute, INI_BYTEAASLONGVARBINARY) == 0 || stricmp(attribute, ABBR_BYTEAASLONGVARBINARY) == 0)
-		ci->bytea_as_longvarbinary = atoi(value);
+		ci->bytea_as_longvarbinary = pg_atoi(value);
 	else if (stricmp(attribute, INI_USESERVERSIDEPREPARE) == 0 || stricmp(attribute, ABBR_USESERVERSIDEPREPARE) == 0)
-		ci->use_server_side_prepare = atoi(value);
+		ci->use_server_side_prepare = pg_atoi(value);
 	else if (stricmp(attribute, INI_LOWERCASEIDENTIFIER) == 0 || stricmp(attribute, ABBR_LOWERCASEIDENTIFIER) == 0)
-		ci->lower_case_identifier = atoi(value);
+		ci->lower_case_identifier = pg_atoi(value);
 	else if (stricmp(attribute, INI_KEEPALIVETIME) == 0 || stricmp(attribute, ABBR_KEEPALIVETIME) == 0)
-		ci->keepalive_idle = atoi(value);
+		ci->keepalive_idle = pg_atoi(value);
 	else if (stricmp(attribute, INI_KEEPALIVEINTERVAL) == 0 || stricmp(attribute, ABBR_KEEPALIVEINTERVAL) == 0)
-		ci->keepalive_interval = atoi(value);
+		ci->keepalive_interval = pg_atoi(value);
 	else if (stricmp(attribute, INI_BATCHSIZE) == 0 || stricmp(attribute, ABBR_BATCHSIZE) == 0)
-		ci->batch_size = atoi(value);
+		ci->batch_size = pg_atoi(value);
 	else if (stricmp(attribute, INI_OPTIONAL_ERRORS) == 0 || stricmp(attribute, ABBR_OPTIONAL_ERRORS) == 0)
-		ci->optional_errors = atoi(value);
+		ci->optional_errors = pg_atoi(value);
 	else if (stricmp(attribute, INI_IGNORETIMEOUT) == 0 || stricmp(attribute, ABBR_IGNORETIMEOUT) == 0)
-		ci->ignore_timeout = atoi(value);
+		ci->ignore_timeout = pg_atoi(value);
 	else if (stricmp(attribute, INI_SSLMODE) == 0 || stricmp(attribute, ABBR_SSLMODE) == 0)
 	{
 		switch (value[0])
@@ -745,7 +745,7 @@ copyConnAttributes(ConnInfo *ci, const char *attribute, const char *value)
 		unfoldCXAttribute(ci, value);
 #ifdef	_HANDLE_ENLIST_IN_DTC_
 	else if (stricmp(attribute, INI_XAOPT) == 0)
-		ci->xa_opt = atoi(value);
+		ci->xa_opt = pg_atoi(value);
 #endif /* _HANDLE_ENLIST_IN_DTC_ */
 	else if (stricmp(attribute, INI_EXTRAOPTIONS) == 0)
 	{
@@ -771,38 +771,38 @@ copyConnAttributes(ConnInfo *ci, const char *attribute, const char *value)
 	}
 
 	else if (stricmp(attribute, INI_FETCH) == 0 || stricmp(attribute, ABBR_FETCH) == 0)
-		ci->drivers.fetch_max = atoi(value);
+		ci->drivers.fetch_max = pg_atoi(value);
 	else if (stricmp(attribute, INI_DEBUG) == 0 || stricmp(attribute, ABBR_DEBUG) == 0)
-		ci->drivers.debug = atoi(value);
+		ci->drivers.debug = pg_atoi(value);
 	else if (stricmp(attribute, INI_COMMLOG) == 0 || stricmp(attribute, ABBR_COMMLOG) == 0)
-		ci->drivers.commlog = atoi(value);
+		ci->drivers.commlog = pg_atoi(value);
 	/*
 	 * else if (stricmp(attribute, INI_UNIQUEINDEX) == 0 ||
 	 * stricmp(attribute, "UIX") == 0) ci->drivers.unique_index =
-	 * atoi(value);
+	 * pg_atoi(value);
 	 */
 	else if (stricmp(attribute, INI_UNKNOWNSIZES) == 0 || stricmp(attribute, ABBR_UNKNOWNSIZES) == 0)
-		ci->drivers.unknown_sizes = atoi(value);
+		ci->drivers.unknown_sizes = pg_atoi(value);
 	else if (stricmp(attribute, INI_LIE) == 0)
-		ci->drivers.lie = atoi(value);
+		ci->drivers.lie = pg_atoi(value);
 	else if (stricmp(attribute, INI_PARSE) == 0 || stricmp(attribute, ABBR_PARSE) == 0)
-		ci->drivers.parse = atoi(value);
+		ci->drivers.parse = pg_atoi(value);
 	else if (stricmp(attribute, INI_USEDECLAREFETCH) == 0 || stricmp(attribute, ABBR_USEDECLAREFETCH) == 0)
-		ci->drivers.use_declarefetch = atoi(value);
+		ci->drivers.use_declarefetch = pg_atoi(value);
 	else if (stricmp(attribute, INI_MAXVARCHARSIZE) == 0 || stricmp(attribute, ABBR_MAXVARCHARSIZE) == 0)
-		ci->drivers.max_varchar_size = atoi(value);
+		ci->drivers.max_varchar_size = pg_atoi(value);
 	else if (stricmp(attribute, INI_MAXLONGVARCHARSIZE) == 0 || stricmp(attribute, ABBR_MAXLONGVARCHARSIZE) == 0)
-		ci->drivers.max_longvarchar_size = atoi(value);
+		ci->drivers.max_longvarchar_size = pg_atoi(value);
 	else if (stricmp(attribute, INI_TEXTASLONGVARCHAR) == 0 || stricmp(attribute, ABBR_TEXTASLONGVARCHAR) == 0)
-		ci->drivers.text_as_longvarchar = atoi(value);
+		ci->drivers.text_as_longvarchar = pg_atoi(value);
 	else if (stricmp(attribute, INI_UNKNOWNSASLONGVARCHAR) == 0 || stricmp(attribute, ABBR_UNKNOWNSASLONGVARCHAR) == 0)
-		ci->drivers.unknowns_as_longvarchar = atoi(value);
+		ci->drivers.unknowns_as_longvarchar = pg_atoi(value);
 	else if (stricmp(attribute, INI_BOOLSASCHAR) == 0 || stricmp(attribute, ABBR_BOOLSASCHAR) == 0)
-		ci->drivers.bools_as_char = atoi(value);
+		ci->drivers.bools_as_char = pg_atoi(value);
 	else if (stricmp(attribute, INI_EXTRASYSTABLEPREFIXES) == 0 || stricmp(attribute, ABBR_EXTRASYSTABLEPREFIXES) == 0)
 		STRCPY_FIXED(ci->drivers.extra_systable_prefixes, value);
 	else if (stricmp(attribute, INI_FETCHREFCURSORS) == 0 || stricmp(attribute, ABBR_FETCHREFCURSORS) == 0)
-		ci->fetch_refcursors = atoi(value);
+		ci->fetch_refcursors = pg_atoi(value);
 	else
 		found = FALSE;
 
@@ -976,9 +976,9 @@ MYLOG(0, "drivername=%s\n", drivername);
 
 	/* It's appropriate to handle debug and commlog here */
 	if (SQLGetPrivateProfileString(DSN, INI_DEBUG, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->drivers.debug = atoi(temp);
+		ci->drivers.debug = pg_atoi(temp);
 	if (SQLGetPrivateProfileString(DSN, INI_COMMLOG, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->drivers.commlog = atoi(temp);
+		ci->drivers.commlog = pg_atoi(temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_READONLY, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
 		STRCPY_FIXED(ci->onlyread, temp);
@@ -1003,7 +1003,7 @@ MYLOG(0, "drivername=%s\n", drivername);
 		if (ptr = strchr(temp, '-'), NULL != ptr)
 		{
 			*ptr = '\0';
-			ci->rollback_on_error = atoi(ptr + 1);
+			ci->rollback_on_error = pg_atoi(ptr + 1);
 			MYLOG(0, "rollback_on_error=%d\n", ci->rollback_on_error);
 		}
 	}
@@ -1052,53 +1052,53 @@ MYLOG(0, "drivername=%s\n", drivername);
 		STRCPY_FIXED(ci->translation_option, temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_UPDATABLECURSORS, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->allow_keyset = atoi(temp);
+		ci->allow_keyset = pg_atoi(temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_LFCONVERSION, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->lf_conversion = atoi(temp);
+		ci->lf_conversion = pg_atoi(temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_TRUEISMINUS1, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->true_is_minus1 = atoi(temp);
+		ci->true_is_minus1 = pg_atoi(temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_INT8AS, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->int8_as = atoi(temp);
+		ci->int8_as = pg_atoi(temp);
 
 	if (SQLGetPrivateProfileString(DSN, ABBR_NUMERIC_AS, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->numeric_as = atoi(temp);
+		ci->numeric_as = pg_atoi(temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_OPTIONAL_ERRORS, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->optional_errors = atoi(temp);
+		ci->optional_errors = pg_atoi(temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_BYTEAASLONGVARBINARY, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->bytea_as_longvarbinary = atoi(temp);
+		ci->bytea_as_longvarbinary = pg_atoi(temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_USESERVERSIDEPREPARE, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->use_server_side_prepare = atoi(temp);
+		ci->use_server_side_prepare = pg_atoi(temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_LOWERCASEIDENTIFIER, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->lower_case_identifier = atoi(temp);
+		ci->lower_case_identifier = pg_atoi(temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_KEEPALIVETIME, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		if (0 == (ci->keepalive_idle = atoi(temp)))
+		if (0 == (ci->keepalive_idle = pg_atoi(temp)))
 			ci->keepalive_idle = -1;
 	if (SQLGetPrivateProfileString(DSN, INI_KEEPALIVEINTERVAL, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		if (0 == (ci->keepalive_interval = atoi(temp)))
+		if (0 == (ci->keepalive_interval = pg_atoi(temp)))
 			ci->keepalive_interval = -1;
 	if (SQLGetPrivateProfileString(DSN, INI_BATCHSIZE, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		if (0 == (ci->batch_size = atoi(temp)))
+		if (0 == (ci->batch_size = pg_atoi(temp)))
 			ci->batch_size = DEFAULT_BATCH_SIZE;
 	if (SQLGetPrivateProfileString(DSN, INI_IGNORETIMEOUT, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->ignore_timeout = atoi(temp);
+		ci->ignore_timeout = pg_atoi(temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_SSLMODE, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
 		STRCPY_FIXED(ci->sslmode, temp);
 
 	if (SQLGetPrivateProfileString(DSN, INI_FETCHREFCURSORS, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->fetch_refcursors = atoi(temp);
+		ci->fetch_refcursors = pg_atoi(temp);
 
 #ifdef	_HANDLE_ENLIST_IN_DTC_
 	if (SQLGetPrivateProfileString(DSN, INI_XAOPT, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->xa_opt = atoi(temp);
+		ci->xa_opt = pg_atoi(temp);
 #endif /* _HANDLE_ENLIST_IN_DTC_ */
 
 	/* Force abbrev connstr or bde */
@@ -1430,59 +1430,59 @@ get_Ci_Drivers(const char *section, const char *filename, GLOBAL_VALUES *comval)
 	if (SQLGetPrivateProfileString(section, INI_FETCH, NULL_STRING,
 				temp, sizeof(temp), filename) > 0)
 	{
-		if (atoi(temp) > 0)
-			comval->fetch_max = atoi(temp);
+		if (pg_atoi(temp) > 0)
+			comval->fetch_max = pg_atoi(temp);
 	}
 
 	/* Recognize Unique Index is stored in the driver section only */
 	if (SQLGetPrivateProfileString(section, INI_UNIQUEINDEX, NULL_STRING,
 				temp, sizeof(temp), filename) > 0)
-		comval->unique_index = atoi(temp);
+		comval->unique_index = pg_atoi(temp);
 
 	/* Unknown Sizes is stored in the driver section only */
 	if (SQLGetPrivateProfileString(section, INI_UNKNOWNSIZES, NULL_STRING,
 				temp, sizeof(temp), filename) > 0)
-		comval->unknown_sizes = atoi(temp);
+		comval->unknown_sizes = pg_atoi(temp);
 
 	/* Lie about supported functions? */
 	if (SQLGetPrivateProfileString(section, INI_LIE, NULL_STRING,
 				temp, sizeof(temp), filename) > 0)
-		comval->lie = atoi(temp);
+		comval->lie = pg_atoi(temp);
 
 	/* Parse statements */
 	if (SQLGetPrivateProfileString(section, INI_PARSE, NULL_STRING,
 				temp, sizeof(temp), filename) > 0)
-		comval->parse = atoi(temp);
+		comval->parse = pg_atoi(temp);
 
 	/* UseDeclareFetch is stored in the driver section only */
 	if (SQLGetPrivateProfileString(section, INI_USEDECLAREFETCH, NULL_STRING,
 				temp, sizeof(temp), filename) > 0)
-		comval->use_declarefetch = atoi(temp);
+		comval->use_declarefetch = pg_atoi(temp);
 
 	/* Max Varchar Size */
 	if (SQLGetPrivateProfileString(section, INI_MAXVARCHARSIZE, NULL_STRING,
 				temp, sizeof(temp), filename) > 0)
-		comval->max_varchar_size = atoi(temp);
+		comval->max_varchar_size = pg_atoi(temp);
 
 	/* Max TextField Size */
 	if (SQLGetPrivateProfileString(section, INI_MAXLONGVARCHARSIZE, NULL_STRING,
 				temp, sizeof(temp), filename) > 0)
-		comval->max_longvarchar_size = atoi(temp);
+		comval->max_longvarchar_size = pg_atoi(temp);
 
 	/* Text As LongVarchar	*/
 	if (SQLGetPrivateProfileString(section, INI_TEXTASLONGVARCHAR, NULL_STRING,
 				temp, sizeof(temp), filename) > 0)
-		comval->text_as_longvarchar = atoi(temp);
+		comval->text_as_longvarchar = pg_atoi(temp);
 
 	/* Unknowns As LongVarchar	*/
 	if (SQLGetPrivateProfileString(section, INI_UNKNOWNSASLONGVARCHAR, NULL_STRING,
 				temp, sizeof(temp), filename) > 0)
-		comval->unknowns_as_longvarchar = atoi(temp);
+		comval->unknowns_as_longvarchar = pg_atoi(temp);
 
 	/* Bools As Char */
 	if (SQLGetPrivateProfileString(section, INI_BOOLSASCHAR, NULL_STRING,
 				temp, sizeof(temp), filename) > 0)
-		comval->bools_as_char = atoi(temp);
+		comval->bools_as_char = pg_atoi(temp);
 
 	/* Extra Systable prefixes */
 

--- a/dlg_wingui.c
+++ b/dlg_wingui.c
@@ -600,11 +600,11 @@ ds_options_update(HWND hdlg, ConnInfo *ci)
 		int	val;
 
 		GetDlgItemText(hdlg, DS_KEEPALIVETIME, temp, sizeof(temp));
-		if  (val = atoi(temp), 0 == val)
+		if  (val = pg_atoi(temp), 0 == val)
 			val = -1;
 		ci->keepalive_idle = val;
 		GetDlgItemText(hdlg, DS_KEEPALIVEINTERVAL, temp, sizeof(temp));
-		if  (val = atoi(temp), 0 == val)
+		if  (val = pg_atoi(temp), 0 == val)
 			val = -1;
 		ci->keepalive_interval = val;
 	}
@@ -651,7 +651,7 @@ ds_options2Proc(HWND hdlg,
 				ShowWindow(GetDlgItem(hdlg, IDAPPLY), SW_HIDE);				}
 
 			/* Readonly */
-			CheckDlgButton(hdlg, DS_READONLY, atoi(ci->onlyread));
+			CheckDlgButton(hdlg, DS_READONLY, pg_atoi(ci->onlyread));
 
 			/* Protocol */
 			enable = (ci->sslmode[0] == SSLLBYTE_DISABLE || ci->username[0] == '\0');
@@ -712,10 +712,10 @@ ds_options2Proc(HWND hdlg,
 			SPRINTF_FIXED(buf, "0x%x", getExtraOptions(ci));
 			SetDlgItemText(hdlg, DS_EXTRA_OPTIONS, buf);
 
-			CheckDlgButton(hdlg, DS_SHOWOIDCOLUMN, atoi(ci->show_oid_column));
-			CheckDlgButton(hdlg, DS_FAKEOIDINDEX, atoi(ci->fake_oid_index));
-			CheckDlgButton(hdlg, DS_ROWVERSIONING, atoi(ci->row_versioning));
-			CheckDlgButton(hdlg, DS_SHOWSYSTEMTABLES, atoi(ci->show_system_tables));
+			CheckDlgButton(hdlg, DS_SHOWOIDCOLUMN, pg_atoi(ci->show_oid_column));
+			CheckDlgButton(hdlg, DS_FAKEOIDINDEX, pg_atoi(ci->fake_oid_index));
+			CheckDlgButton(hdlg, DS_ROWVERSIONING, pg_atoi(ci->row_versioning));
+			CheckDlgButton(hdlg, DS_SHOWSYSTEMTABLES, pg_atoi(ci->show_system_tables));
 			CheckDlgButton(hdlg, DS_LFCONVERSION, ci->lf_conversion);
 			CheckDlgButton(hdlg, DS_OPTIONALERRORS, ci->optional_errors);
 			CheckDlgButton(hdlg, DS_TRUEISMINUS1, ci->true_is_minus1);
@@ -725,7 +725,7 @@ ds_options2Proc(HWND hdlg,
 			CheckDlgButton(hdlg, DS_FETCH_REFCURSORS, ci->fetch_refcursors);
 			/*CheckDlgButton(hdlg, DS_LOWERCASEIDENTIFIER, ci->lower_case_identifier);*/
 
-			EnableWindow(GetDlgItem(hdlg, DS_FAKEOIDINDEX), atoi(ci->show_oid_column));
+			EnableWindow(GetDlgItem(hdlg, DS_FAKEOIDINDEX), pg_atoi(ci->show_oid_column));
 
 			/* Datasource Connection Settings */
 			SetDlgItemText(hdlg, DS_CONNSETTINGS, SAFE_NAME(ci->conn_settings));

--- a/info.c
+++ b/info.c
@@ -2021,7 +2021,7 @@ retry_public_schema:
 	 * some time on the query.	If treating system tables as regular
 	 * tables, then dont filter either.
 	 */
-	if ((list_schemas || !list_some) && !atoi(ci->show_system_tables) && !show_system_tables)
+	if ((list_schemas || !list_some) && !pg_atoi(ci->show_system_tables) && !show_system_tables)
 		appendPQExpBufferStr(&tables_query, " and nspname not in ('pg_catalog', 'information_schema', 'pg_toast', 'pg_temp_1')");
 
 	if (!list_some)
@@ -2119,7 +2119,7 @@ retry_public_schema:
 		 * system tables as regular tables, then no need to do this test.
 		 */
 		systable = FALSE;
-		if (!atoi(ci->show_system_tables))
+		if (!pg_atoi(ci->show_system_tables))
 		{
 			if (stricmp(table_owner, "pg_catalog") == 0 ||
 			    stricmp(table_owner, "pg_toast") == 0 ||
@@ -2756,7 +2756,7 @@ MYLOG(0, " and the data=%s\n", attdef);
 		switch (field_type)
 		{
 			case PG_TYPE_OID:
-				if (0 != atoi(ci->fake_oid_index))
+				if (0 != pg_atoi(ci->fake_oid_index))
 				{
 					auto_unique = SQL_TRUE;
 					set_tuplefield_string(&tuple[COLUMNS_TYPE_NAME], "identity");
@@ -3569,7 +3569,7 @@ PGAPI_Statistics(HSTMT hstmt,
 	relhasrules[0] = '0';
 	result = PGAPI_Fetch(indx_stmt);
 	/* fake index of OID */
-	if (relhasoids && relhasrules[0] != '1' && atoi(ci->show_oid_column) && atoi(ci->fake_oid_index))
+	if (relhasoids && relhasrules[0] != '1' && pg_atoi(ci->show_oid_column) && pg_atoi(ci->fake_oid_index))
 	{
 		tuple = QR_AddNew(res);
 
@@ -3605,7 +3605,7 @@ PGAPI_Statistics(HSTMT hstmt,
 	{
 		/* If only requesting unique indexes, then just return those. */
 		if (fUnique == SQL_INDEX_ALL ||
-			(fUnique == SQL_INDEX_UNIQUE && atoi(isunique)))
+			(fUnique == SQL_INDEX_UNIQUE && pg_atoi(isunique)))
 		{
 			int	colcnt, attnum;
 
@@ -3623,7 +3623,7 @@ PGAPI_Statistics(HSTMT hstmt,
 
 				/* non-unique index? */
 				if (ci->drivers.unique_index)
-					set_tuplefield_int2(&tuple[STATS_NON_UNIQUE], (Int2) (atoi(isunique) ? FALSE : TRUE));
+					set_tuplefield_int2(&tuple[STATS_NON_UNIQUE], (Int2) (pg_atoi(isunique) ? FALSE : TRUE));
 				else
 					set_tuplefield_int2(&tuple[STATS_NON_UNIQUE], TRUE);
 
@@ -3635,7 +3635,7 @@ PGAPI_Statistics(HSTMT hstmt,
 				 * Clustered/HASH index?
 				 */
 				set_tuplefield_int2(&tuple[STATS_TYPE], (Int2)
-							   (atoi(isclustered) ? SQL_INDEX_CLUSTERED :
+							   (pg_atoi(isclustered) ? SQL_INDEX_CLUSTERED :
 								(!strncmp(ishash, "hash", 4)) ? SQL_INDEX_HASHED : SQL_INDEX_OTHER));
 				set_tuplefield_int2(&tuple[STATS_SEQ_IN_INDEX], (Int2) i);
 
@@ -5466,7 +5466,7 @@ MYLOG(0, "atttypid=%s\n", atttypid ? atttypid : "(null)");
 			}
 			else
 			{
-				typid = atoi(atttypid);
+				typid = pg_atoi(atttypid);
 				attname = QR_get_value_backend_text(tres, i, attname_pos);
 			}
 			tuple = QR_AddNew(res);

--- a/mylog.c
+++ b/mylog.c
@@ -503,7 +503,7 @@ getGlobalDebug()
 	/* Debug is stored in the driver section */
 	SQLGetPrivateProfileString(DBMS_NAME, INI_DEBUG, "", temp, sizeof(temp), ODBCINST_INI);
 	if (temp[0])
-		globalDebug = atoi(temp);
+		globalDebug = pg_atoi(temp);
 	else
 		globalDebug = DEFAULT_DEBUG;
 
@@ -527,7 +527,7 @@ getGlobalCommlog()
 	/* Commlog is stored in the driver section */
 	SQLGetPrivateProfileString(DBMS_NAME, INI_COMMLOG, "", temp, sizeof(temp), ODBCINST_INI);
 	if (temp[0])
-		globalCommlog = atoi(temp);
+		globalCommlog = pg_atoi(temp);
 	else
 		globalCommlog = DEFAULT_COMMLOG;
 

--- a/odbcapi.c
+++ b/odbcapi.c
@@ -115,9 +115,9 @@ SQLColumns(HSTMT StatementHandle,
 	StartRollbackState(stmt);
 	if (stmt->options.metadata_id)
 		flag |= PODBC_NOT_SEARCH_PATTERN;
-	if (atoi(ci->show_oid_column))
+	if (pg_atoi(ci->show_oid_column))
 		flag |= PODBC_SHOW_OID_COLUMN;
-	if (atoi(ci->row_versioning))
+	if (pg_atoi(ci->row_versioning))
 		flag |= PODBC_ROW_VERSIONING;
 	if (SC_opencheck(stmt, func))
 		ret = SQL_ERROR;

--- a/odbcapiw.c
+++ b/odbcapiw.c
@@ -59,9 +59,9 @@ SQLColumnsW(HSTMT StatementHandle,
 	StartRollbackState(stmt);
 	if (stmt->options.metadata_id)
 		flag |= PODBC_NOT_SEARCH_PATTERN;
-	if (atoi(ci->show_oid_column))
+	if (pg_atoi(ci->show_oid_column))
 		flag |= PODBC_SHOW_OID_COLUMN;
-	if (atoi(ci->row_versioning))
+	if (pg_atoi(ci->row_versioning))
 		flag |= PODBC_ROW_VERSIONING;
 	if (SC_opencheck(stmt, func))
 		ret = SQL_ERROR;

--- a/parse.c
+++ b/parse.c
@@ -296,7 +296,7 @@ MYLOG(DETAIL_LOG_LEVEL, "entering non-manual result\n");
 	fi->column_size = QR_get_value_backend_int(col_info->result, k, COLUMNS_PRECISION, NULL);
 	fi->length = QR_get_value_backend_int(col_info->result, k, COLUMNS_LENGTH, NULL);
 	if (str = QR_get_value_backend_text(col_info->result, k, COLUMNS_SCALE), str)
-		fi->decimal_digits = atoi(str);
+		fi->decimal_digits = pg_atoi(str);
 	else
 		fi->decimal_digits = -1;
 	fi->nullable = QR_get_value_backend_int(col_info->result, k, COLUMNS_NULLABLE, NULL);

--- a/pgxalib.cpp
+++ b/pgxalib.cpp
@@ -232,7 +232,7 @@ INT_PTR FAR WINAPI GetMsdtclog()
 	char	temp[16];
 
         SQLGetPrivateProfileString(DBMSNAME, KEY_NAME, "", temp, sizeof(temp), ODBCINST_INI);
-	dtclog = atoi(temp);
+	dtclog = (int) strtol(temp, NULL, 10);
 	return dtclog;
 }
 INT_PTR FAR WINAPI SetMsdtclog(int dtclog)
@@ -520,10 +520,10 @@ void XAConnection::parse_xa_info()
 		}
 
 		if (0 == _stricmp(keyword, KEYWORD_DTC_CHECK))
-			immediateConnection = (0 != atoi(value)); 
+			immediateConnection = (0 != (int) strtol(value, NULL, 10));
 		else if (0 == _stricmp(keyword, KEYWORD_DEBUG) ||
 			 0 == _stricmp(keyword, KEYWORD_ABDEBUG))
-			debugv = atoi(value); 
+			debugv = (int) strtol(value, NULL, 10);
 		else
 		{
 			if (keyhasbr)

--- a/psqlodbc.h
+++ b/psqlodbc.h
@@ -69,6 +69,14 @@
 #endif  /* __GNUC__ || __IBMC__ */
 #endif  /* __INCLUDE_POSTGRES_FE_H__ */
 
+/*
+ * safe string-to-number conversions
+ */
+#define pg_atoi(val) (int) strtol(val, NULL, 10)
+#define pg_atof(val) strtod(val, NULL)
+#define pg_atol(val) strtol(val, NULL, 10)
+#define pg_atoll(val) strtoll(val, NULL, 10)
+
 #ifdef	_MIMALLOC_
 #include <mimalloc.h>
 #define pg_malloc	mi_malloc

--- a/qresult.h
+++ b/qresult.h
@@ -132,7 +132,7 @@ enum {
 #define QR_get_value_backend(self, fieldno)	(self->tupleField[fieldno].value)
 #define QR_get_value_backend_row(self, tupleno, fieldno) ((self->backend_tuples + (tupleno * self->num_fields))[fieldno].value)
 #define QR_get_value_backend_text(self, tupleno, fieldno) QR_get_value_backend_row(self, tupleno, fieldno)
-#define QR_get_value_backend_int(self, tupleno, fieldno, isNull) atoi(QR_get_value_backend_row(self, tupleno, fieldno))
+#define QR_get_value_backend_int(self, tupleno, fieldno, isNull) pg_atoi(QR_get_value_backend_row(self, tupleno, fieldno))
 
 /*	These functions are used by both manual and backend results */
 #define QR_NumResultCols(self)		(CI_get_num_fields(self->fields))

--- a/statement.c
+++ b/statement.c
@@ -2750,7 +2750,7 @@ MYLOG(DETAIL_LOG_LEVEL, "get_Result=%p %p\n", res, SC_get_Result(stmt));
 			/* get rowcount */
 			rowcount = PQcmdTuples(pgres);
 			if (rowcount && rowcount[0])
-				res->recent_processed_row_count = atoi(rowcount);
+				res->recent_processed_row_count = pg_atoi(rowcount);
 			else
 				res->recent_processed_row_count = -1;
 			break;


### PR DESCRIPTION
The following functions
```
atoi()
atol()
atoll()
atof()
```
have been deprecated by the `strto...` variants. 

This commit adds a new set of macros prefixed with `pg_` in `psqlodbc.h` to convert the `ato..()` calls to their respective `strto...` versions. 