### PR TITLE
chore: change memset to memset_s/SecureZeroMemory

### DIFF
--- a/bind.c
+++ b/bind.c
@@ -522,7 +522,7 @@ extend_parameter_bindings(APDFields *self, int num_params)
 			self->allocated = 0;
 			return;
 		}
-		memset(&new_bindings[self->allocated], 0, sizeof(ParameterInfoClass) * (num_params - self->allocated));
+		pg_memset(&new_bindings[self->allocated], 0, sizeof(ParameterInfoClass) * (num_params - self->allocated));
 
 		self->parameters = new_bindings;
 		self->allocated = num_params;
@@ -555,7 +555,7 @@ extend_iparameter_bindings(IPDFields *self, int num_params)
 			self->allocated = 0;
 			return;
 		}
-		memset(&new_bindings[self->allocated], 0,
+		pg_memset(&new_bindings[self->allocated], 0,
 			sizeof(ParameterImplClass) * (num_params - self->allocated));
 
 		self->parameters = new_bindings;
@@ -981,7 +981,7 @@ extend_putdata_info(PutDataInfo *self, int num_params, BOOL shrink)
 			self->allocated = 0;
 			return;
 		}
-		memset(&new_pdata[self->allocated], 0,
+		pg_memset(&new_pdata[self->allocated], 0,
 			sizeof(PutDataClass) * (num_params - self->allocated));
 
 		self->pdata = new_pdata;

--- a/connection.c
+++ b/connection.c
@@ -305,7 +305,7 @@ CC_initialize(ConnectionClass *rv, BOOL lockinit)
 	clear_size = sizeof(ConnectionClass);
 #endif /* WIN_MULTITHREAD_SUPPORT */
 
-	memset(rv, 0, clear_size);
+	pg_memset(rv, 0, clear_size);
 	rv->status = CONN_NOT_CONNECTED;
 	rv->transact_status = CONN_IN_AUTOCOMMIT;		/* autocommit by default */
 	rv->unnamed_prepared_stmt = NULL;
@@ -313,13 +313,13 @@ CC_initialize(ConnectionClass *rv, BOOL lockinit)
 	rv->stmts = (StatementClass **) malloc(sizeof(StatementClass *) * STMT_INCREMENT);
 	if (!rv->stmts)
 		goto cleanup;
-	memset(rv->stmts, 0, sizeof(StatementClass *) * STMT_INCREMENT);
+	pg_memset(rv->stmts, 0, sizeof(StatementClass *) * STMT_INCREMENT);
 
 	rv->num_stmts = STMT_INCREMENT;
 	rv->descs = (DescriptorClass **) malloc(sizeof(DescriptorClass *) * STMT_INCREMENT);
 	if (!rv->descs)
 		goto cleanup;
-	memset(rv->descs, 0, sizeof(DescriptorClass *) * STMT_INCREMENT);
+	pg_memset(rv->descs, 0, sizeof(DescriptorClass *) * STMT_INCREMENT);
 
 	rv->num_descs = STMT_INCREMENT;
 
@@ -1250,7 +1250,7 @@ CC_add_statement(ConnectionClass *self, StatementClass *stmt)
 		else
 		{
 			self->stmts = newstmts;
-			memset(&self->stmts[self->num_stmts], 0, sizeof(StatementClass *) * STMT_INCREMENT);
+			pg_memset(&self->stmts[self->num_stmts], 0, sizeof(StatementClass *) * STMT_INCREMENT);
 
 			stmt->hdbc = self;
 			self->stmts[self->num_stmts] = stmt;

--- a/connection.h
+++ b/connection.h
@@ -256,7 +256,7 @@ enum {
 	coli->refcnt = 0; \
 	coli->acc_time = 0; \
 }
-#define col_info_initialize(coli) (memset(coli, 0, sizeof(COL_INFO)))
+#define col_info_initialize(coli) (pg_memset(coli, 0, sizeof(COL_INFO)))
 
  /* Translation DLL entry points */
 #ifdef WIN32

--- a/convert.c
+++ b/convert.c
@@ -574,7 +574,7 @@ interval2istruct(SQLSMALLINT ctype, int precision, const char *str, SQL_INTERVAL
 	BOOL	sign;
 	SQLINTERVAL	itype = interval2itype(ctype);
 
-	memset(st, 0, sizeof(SQL_INTERVAL_STRUCT));
+	pg_memset(st, 0, sizeof(SQL_INTERVAL_STRUCT));
 	if ((scnt = sscanf(str, "%d-%d", &years, &mons)) >=2)
 	{
 		if (SQL_IS_YEAR_TO_MONTH == itype)
@@ -1324,7 +1324,7 @@ copy_and_convert_field(StatementClass *stmt,
 		*pIndicatorBindRow = 0;
 	}
 
-	memset(&std_time, 0, sizeof(SIMPLE_TIME));
+	pg_memset(&std_time, 0, sizeof(SIMPLE_TIME));
 
 	MYLOG(0, "field_type = %d, fctype = %d, value = '%s', cbValueMax=" FORMAT_LEN "\n", field_type, fCType, (value == NULL) ? "<NULL>" : value, cbValueMax);
 
@@ -1359,7 +1359,7 @@ MYLOG(0, "null_cvt_date_string=%d\n", conn->connInfo.cvt_null_date_string);
 				case SQL_C_DEFAULT:
 					if (rgbValueBindRow && cbValueMax >= sizeof(DATE_STRUCT))
 					{
-						memset(rgbValueBindRow, 0, cbValueMax);
+						pg_memset(rgbValueBindRow, 0, cbValueMax);
 						if (pcbValueBindRow)
 							*pcbValueBindRow = sizeof(DATE_STRUCT);
 					}
@@ -1369,7 +1369,7 @@ MYLOG(0, "null_cvt_date_string=%d\n", conn->connInfo.cvt_null_date_string);
 #ifdef	UNICODE_SUPPORT
 				case SQL_C_WCHAR:
 					if (rgbValueBindRow && cbValueMax >= WCLEN)
-						memset(rgbValueBindRow, 0, WCLEN);
+						pg_memset(rgbValueBindRow, 0, WCLEN);
 					else
 						result = COPY_RESULT_TRUNCATED;
 					break;
@@ -3721,7 +3721,7 @@ inner_process_tokens(QueryParse *qp, QueryBuild *qb)
 		{
 			TABLE_INFO	ti, *pti = &ti;
 
-			memset(&ti, 0, sizeof(ti));
+			pg_memset(&ti, 0, sizeof(ti));
 			NAME_TO_NAME(ti.schema_name, conn->schemaIns);
 			NAME_TO_NAME(ti.table_name, conn->tableIns);
 			getCOLIfromTI(func, conn, qb->stmt, 0, &pti);
@@ -4063,7 +4063,7 @@ build_libpq_bind_params(StatementClass *stmt,
 		*paramValues = malloc(sizeof(char *) * num_params);
 		if (*paramValues == NULL)
 			goto cleanup;
-		memset(*paramValues, 0, sizeof(char *) * num_params);
+		pg_memset(*paramValues, 0, sizeof(char *) * num_params);
 		*paramLengths = malloc(sizeof(int) * num_params);
 		if (*paramLengths == NULL)
 			goto cleanup;
@@ -4332,7 +4332,7 @@ parse_to_numeric_struct(const char *wv, SQL_NUMERIC_STRUCT *ns, BOOL *overflow)
 	ns->precision = nlen;
 
 	/* Convert the decimal digits to binary */
-	memset(ns->val, 0, sizeof(ns->val));
+	pg_memset(ns->val, 0, sizeof(ns->val));
 	for (dig = 0; dig < nlen; dig++)
 	{
 		UInt4 carry;
@@ -4721,7 +4721,7 @@ MYLOG(DETAIL_LOG_LEVEL, "ipara=%p paramName=%s paramType=%d %d proc_return=%d\n"
 	send_buf = NULL;
 	param_string[0] = '\0';
 	cbuf[0] = '\0';
-	memset(&st, 0, sizeof(st));
+	pg_memset(&st, 0, sizeof(st));
 
 	ivstruct = (SQL_INTERVAL_STRUCT *) buffer;
 	/* Convert input C type to a neutral format */

--- a/descriptor.c
+++ b/descriptor.c
@@ -27,7 +27,7 @@
 
 void	TI_Constructor(TABLE_INFO *self, const ConnectionClass *conn)
 {
-	memset(self, 0, sizeof(TABLE_INFO));
+	pg_memset(self, 0, sizeof(TABLE_INFO));
 	TI_set_updatable(self);
 }
 void	TI_Destructor(TABLE_INFO **ti, int count)
@@ -83,7 +83,7 @@ void	FI_Constructor(FIELD_INFO *self, BOOL reuse)
 MYLOG(DETAIL_LOG_LEVEL, "entering reuse=%d\n", reuse);
 	if (reuse)
 		FI_Destructor(&self, 1, FALSE);
-	memset(self, 0, sizeof(FIELD_INFO));
+	pg_memset(self, 0, sizeof(FIELD_INFO));
 	self->nullable = TRUE;
 	self->columnkey = -1;
 	self->typmod = -1;
@@ -124,7 +124,7 @@ void	TI_Create_IH(TABLE_INFO *ti)
 	InheritanceClass	*ih;
 
 	ih = (InheritanceClass *) malloc(sizeof(InheritanceClass) + (alloc - 1) * sizeof(ih->inf[0]));
-	memset(ih, 0, sizeof(InheritanceClass));
+	pg_memset(ih, 0, sizeof(InheritanceClass));
 	ih->allocated = alloc;
 	ti->ih = ih;
 }
@@ -201,7 +201,7 @@ const pgNAME	TI_Ins_IH(TABLE_INFO *ti, OID tableoid, const char *fullName)
 
 void	DC_Constructor(DescriptorClass *self, BOOL embedded, StatementClass *stmt)
 {
-	memset(self, 0, sizeof(DescriptorClass));
+	pg_memset(self, 0, sizeof(DescriptorClass));
 	self->deschd.embedded = embedded;
 }
 
@@ -294,22 +294,22 @@ void InitializeEmbeddedDescriptor(DescriptorClass *self, StatementClass *stmt,
 	switch (desc_type)
 	{
 		case SQL_ATTR_APP_ROW_DESC:
-			memset(&(self->ardf), 0, sizeof(ARDFields));
+			pg_memset(&(self->ardf), 0, sizeof(ARDFields));
 			InitializeARDFields(&(self->ardf));
 			stmt->ard = self;
 			break;
 		case SQL_ATTR_APP_PARAM_DESC:
-			memset(&(self->apdf), 0, sizeof(APDFields));
+			pg_memset(&(self->apdf), 0, sizeof(APDFields));
 			InitializeAPDFields(&(self->apdf));
 			stmt->apd = self;
 			break;
 		case SQL_ATTR_IMP_ROW_DESC:
-			memset(&(self->irdf), 0, sizeof(IRDFields));
+			pg_memset(&(self->irdf), 0, sizeof(IRDFields));
 			stmt->ird = self;
 			stmt->ird->irdf.stmt = stmt;
 			break;
 		case SQL_ATTR_IMP_PARAM_DESC:
-			memset(&(self->ipdf), 0, sizeof(IPDFields));
+			pg_memset(&(self->ipdf), 0, sizeof(IPDFields));
 			stmt->ipd = self;
 			break;
 	}
@@ -321,7 +321,7 @@ void InitializeEmbeddedDescriptor(DescriptorClass *self, StatementClass *stmt,
 void
 InitializeARDFields(ARDFields *opt)
 {
-	memset(opt, 0, sizeof(ARDFields));
+	pg_memset(opt, 0, sizeof(ARDFields));
 	opt->size_of_rowset = 1;
 	opt->bind_size = 0;		/* default is to bind by column */
 	opt->size_of_rowset_odbc2 = 1;
@@ -332,7 +332,7 @@ InitializeARDFields(ARDFields *opt)
 void
 InitializeAPDFields(APDFields *opt)
 {
-	memset(opt, 0, sizeof(APDFields));
+	pg_memset(opt, 0, sizeof(APDFields));
 	opt->paramset_size = 1;
 	opt->param_bind_type = 0;	/* default is to bind by column */
 	opt->paramset_size_dummy = 1;	/* dummy setting */
@@ -343,7 +343,7 @@ BindInfoClass	*ARD_AllocBookmark(ARDFields *ardopts)
 	if (!ardopts->bookmark)
 	{
 		ardopts->bookmark = (BindInfoClass *) malloc(sizeof(BindInfoClass));
-		memset(ardopts->bookmark, 0, sizeof(BindInfoClass));
+		pg_memset(ardopts->bookmark, 0, sizeof(BindInfoClass));
 	}
 	return ardopts->bookmark;
 }
@@ -373,7 +373,7 @@ char CC_add_descriptor(ConnectionClass *self, DescriptorClass *desc)
 		return FALSE;
 	self->descs = descs;
 
-	memset(&self->descs[self->num_descs], 0, sizeof(DescriptorClass *) *
+	pg_memset(&self->descs[self->num_descs], 0, sizeof(DescriptorClass *) *
 				DESC_INCREMENT);
         DC_get_conn(desc) = self;
 	self->descs[self->num_descs] = desc;
@@ -399,7 +399,7 @@ PGAPI_AllocDesc(HDBC ConnectionHandle,
 	desc = (DescriptorClass *) malloc(sizeof(DescriptorClass));
 	if (desc)
 	{
-		memset(desc, 0, sizeof(DescriptorClass));
+		pg_memset(desc, 0, sizeof(DescriptorClass));
 		DC_get_conn(desc) = conn;
 		if (CC_add_descriptor(conn, desc))
 			*DescriptorHandle = desc;

--- a/dlg_specific.c
+++ b/dlg_specific.c
@@ -1783,7 +1783,7 @@ CC_conninfo_init(ConnInfo *conninfo, UInt4 option)
 
 	if (0 != (CLEANUP_FOR_REUSE & option))
 		CC_conninfo_release(conninfo);
-	memset(conninfo, 0, sizeof(ConnInfo));
+	pg_memset(conninfo, 0, sizeof(ConnInfo));
 
 	conninfo->allow_keyset = -1;
 	conninfo->lf_conversion = -1;
@@ -1818,7 +1818,7 @@ CC_conninfo_init(ConnInfo *conninfo, UInt4 option)
 
 void	init_globals(GLOBAL_VALUES *glbv)
 {
-	memset(glbv, 0, sizeof(*glbv));
+	pg_memset(glbv, 0, sizeof(*glbv));
 	glbv->debug = -1;
 	glbv->commlog = -1;
 }
@@ -1828,7 +1828,7 @@ void	init_globals(GLOBAL_VALUES *glbv)
 
 void	copy_globals(GLOBAL_VALUES *to, const GLOBAL_VALUES *from)
 {
-	memset(to, 0, sizeof(*to));
+	pg_memset(to, 0, sizeof(*to));
 	/***
 	memcpy(to, from, sizeof(GLOBAL_VALUES));
 	SET_NAME_DIRECTLY(to->drivername, NULL);
@@ -1866,7 +1866,7 @@ void	finalize_globals(GLOBAL_VALUES *glbv)
 void
 CC_copy_conninfo(ConnInfo *ci, const ConnInfo *sci)
 {
-	memset(ci, 0,sizeof(ConnInfo));
+	pg_memset(ci, 0,sizeof(ConnInfo));
 
 	CORR_STRCPY(dsn);
 	CORR_STRCPY(desc);

--- a/drvconn.c
+++ b/drvconn.c
@@ -168,7 +168,7 @@ PGAPI_DriverConnect(HDBC hdbc,
 
 	/* initialize pg_version */
 	CC_initialize_pg_version(conn);
-	memset(salt, 0, sizeof(salt));
+	pg_memset(salt, 0, sizeof(salt));
 
 #ifdef WIN32
 dialog:

--- a/environ.c
+++ b/environ.c
@@ -148,7 +148,7 @@ ER_Constructor(SDWORD errnumber, const char *msg)
 	error = (PG_ErrorInfo *) malloc(sizeof(PG_ErrorInfo) + aladd);
 	if (error)
 	{
-		memset(error, 0, sizeof(PG_ErrorInfo));
+		pg_memset(error, 0, sizeof(PG_ErrorInfo));
 		error->status = errnumber;
 		error->errsize = errsize;
 		if (errsize > 0)

--- a/info.c
+++ b/info.c
@@ -1341,7 +1341,7 @@ PGAPI_GetFunctions(HDBC hdbc,
 
 	if (fFunction == SQL_API_ALL_FUNCTIONS)
 	{
-		memset(pfExists, 0, sizeof(pfExists[0]) * 100);
+		pg_memset(pfExists, 0, sizeof(pfExists[0]) * 100);
 
 		/* ODBC core functions */
 		pfExists[SQL_API_SQLALLOCCONNECT] = TRUE;
@@ -5805,7 +5805,7 @@ retry_public_schema:
 	}
 	for (i = 0; i < tablecount; i++)
 	{
-		memset(useracl, 0, usercount * sizeof(char[ACLMAX]));
+		pg_memset(useracl, 0, usercount * sizeof(char[ACLMAX]));
 		acl = (char *) QR_get_value_backend_text(wres, i, 2);
 		if (acl && acl[0] == '{')
 			user = acl + 1;

--- a/inouealc.c
+++ b/inouealc.c
@@ -245,7 +245,7 @@ void *pgdebug_memset(void *out, int c, size_t len)
 		return NULL;
 	}
 	out_check(out, len, __FUNCTION__);
-	return memset(out, c, len);
+	return memset_s(out, len, c, len);
 }
 
 void debug_memory_check(void)

--- a/odbcapi30.c
+++ b/odbcapi30.c
@@ -585,7 +585,7 @@ MYLOG(DETAIL_LOG_LEVEL, "lie=%d\n", ci->drivers.lie);
 	CC_clear_error(conn);
 	if (fFunction != SQL_API_ODBC3_ALL_FUNCTIONS)
 		return SQL_ERROR;
-	memset(pfExists, 0, sizeof(UWORD) * SQL_API_ODBC3_ALL_FUNCTIONS_SIZE);
+	pg_memset(pfExists, 0, sizeof(UWORD) * SQL_API_ODBC3_ALL_FUNCTIONS_SIZE);
 
 	/* SQL_FUNC_ESET(pfExists, SQL_API_SQLALLOCCONNECT); 1 deprecated */
 	/* SQL_FUNC_ESET(pfExists, SQL_API_SQLALLOCENV); 2 deprecated */

--- a/parse.c
+++ b/parse.c
@@ -556,7 +556,7 @@ static BOOL allocateFields(IRDFields *irdflds, size_t sizeRequested)
 		irdflds->allocated = irdflds->nfields = 0;
 		return FALSE;
 	}
-	memset(&fi[irdflds->allocated], 0, incr_size);
+	pg_memset(&fi[irdflds->allocated], 0, incr_size);
 	irdflds->fi = fi;
 	irdflds->allocated = (SQLSMALLINT) alloc_size;
 

--- a/psqlodbc.h
+++ b/psqlodbc.h
@@ -104,25 +104,30 @@ void		debug_memory_check(void);
 #ifdef	WIN32
 #undef strdup
 #endif /* WIN32 */
-#define malloc	pgdebug_alloc
-#define realloc pgdebug_realloc
-#define calloc	pgdebug_calloc
-#define strdup	pgdebug_strdup
-#define free	pgdebug_free
-#define strcpy	pgdebug_strcpy
-#define strncpy	pgdebug_strncpy
+#define malloc	  	pgdebug_alloc
+#define realloc   	pgdebug_realloc
+#define calloc		pgdebug_calloc
+#define strdup		pgdebug_strdup
+#define free		pgdebug_free
+#define strcpy		pgdebug_strcpy
+#define strncpy		pgdebug_strncpy
 /* #define strncpy_null	pgdebug_strncpy_null */
-#define memcpy	pgdebug_memcpy
-#define memset	pgdebug_memset
+#define memcpy		pgdebug_memcpy
+#define pg_memset(dest, ch, count)	pgdebug_memset(dest, ch, count)
 #else   /* _MEMORY_DEBUG_ */
 #ifdef	WIN32
 #undef strdup
 #endif /* WIN32 */
-#define malloc	pg_malloc
-#define realloc pg_realloc
-#define calloc	pg_calloc
-#define strdup	pg_strdup
-#define free	pg_free
+#define malloc		pg_malloc
+#define realloc 	pg_realloc
+#define calloc		pg_calloc
+#define strdup		pg_strdup
+#define free		pg_free
+#ifdef WIN32
+#define pg_memset(dest, ch, count)	SecureZeroMemory(dest, count)
+#else
+#define pg_memset(dest, ch, count)	memset_s(dest, count, ch, count)
+#endif	  /* WIN32 */
 #endif   /* _MEMORY_DEBUG_ */
 
 #ifdef	WIN32

--- a/qresult.c
+++ b/qresult.c
@@ -473,7 +473,7 @@ MYLOG(DETAIL_LOG_LEVEL, FORMAT_ULEN "th row(%d fields) alloc=" FORMAT_LEN "\n", 
 
 	if (self->backend_tuples)
 	{
-		memset(self->backend_tuples + num_fields * self->num_cached_rows, 0, num_fields * sizeof(TupleField));
+		pg_memset(self->backend_tuples + num_fields * self->num_cached_rows, 0, num_fields * sizeof(TupleField));
 		self->num_cached_rows++;
 		self->ad_count++;
 	}
@@ -842,7 +842,7 @@ MYLOG(DETAIL_LOG_LEVEL, "entering %p->num_fields=%d\n", self, self->num_fields);
 			else
 				tuple_size *= 2;
 			QR_REALLOC_return_with_error(self->keyset, KeySet, sizeof(KeySet) * tuple_size, self, "Out of mwmory while allocating keyset", FALSE);
-			memset(&self->keyset[self->count_keyset_allocated],
+			pg_memset(&self->keyset[self->count_keyset_allocated],
 				   0,
 				   (tuple_size - self->count_keyset_allocated) * sizeof(KeySet));
 			self->count_keyset_allocated = tuple_size;
@@ -1231,7 +1231,7 @@ MYLOG(DETAIL_LOG_LEVEL, "will add " FORMAT_LEN " added_tuples from " FORMAT_LEN 
 				memcpy(self->keyset + num_backend_rows, (void *)(self->added_keyset + start_idx), sizeof(KeySet) * add_size);
 				/* and append the tuples info */
 				tuple = self->backend_tuples + num_fields * num_backend_rows;
-				memset(tuple, 0, sizeof(TupleField) * num_fields * add_size);
+				pg_memset(tuple, 0, sizeof(TupleField) * num_fields * add_size);
 				added_tuple = self->added_tuples + num_fields * start_idx;
 				ReplaceCachedRows(tuple, added_tuple, num_fields, add_size);
 				self->num_cached_rows += add_size;

--- a/results.c
+++ b/results.c
@@ -2368,7 +2368,7 @@ MYLOG(DETAIL_LOG_LEVEL, "entering index=" FORMAT_LEN ", tuple=%p, num_fields=%d\
 	if (added_tuples)
 	{
 		tuple = added_tuples + num_fields * ad_count;
-		memset(tuple, 0, sizeof(TupleField) * num_fields);
+		pg_memset(tuple, 0, sizeof(TupleField) * num_fields);
 		ReplaceCachedRows(tuple, tuple_added, num_fields, 1);
 	}
 }
@@ -2706,7 +2706,7 @@ MYLOG(DETAIL_LOG_LEVEL, "entering index=" FORMAT_LEN "\n", index);
 		if (updated_tuples)
 		{
 			tuple = updated_tuples + num_fields * up_count;
-			memset(tuple, 0, sizeof(TupleField) * num_fields);
+			pg_memset(tuple, 0, sizeof(TupleField) * num_fields);
 		}
 		res->up_count++;
 	}
@@ -3739,7 +3739,7 @@ SC_pos_reload_needed(StatementClass *stmt, SQLULEN req_size, UDWORD flag)
 			res->count_backend_allocated = brows;
 		}
 		if (brows > 0)
-			memset(res->backend_tuples, 0, sizeof(TupleField) * res->num_fields * brows);
+			pg_memset(res->backend_tuples, 0, sizeof(TupleField) * res->num_fields * brows);
 		QR_set_num_cached_rows(res, brows);
 		QR_set_rowstart_in_cache(res, 0);
 		if (SQL_RD_ON != stmt->options.retrieve_data)
@@ -5220,7 +5220,7 @@ MYLOG(0, "i=%d bidx=" FORMAT_LEN " cached=" FORMAT_ULEN "\n", i, bidx, res->num_
 		SC_REALLOC_gexit_with_error(res->backend_tuples, TupleField, size_of_rowset * sizeof(TupleField) * num_fields, hstmt, "Couldn't realloc memory for backend.", (ret = SQL_ERROR));
 		res->count_backend_allocated = size_of_rowset;
 	}
-	memset(res->backend_tuples + num_fields * cached_rows, 0, (size_of_rowset - cached_rows) * num_fields * sizeof(TupleField));
+	pg_memset(res->backend_tuples + num_fields * cached_rows, 0, (size_of_rowset - cached_rows) * num_fields * sizeof(TupleField));
 	QR_set_num_cached_rows(res, size_of_rowset);
 	res->num_total_read = size_of_rowset;
 	rowStatusArray = (SC_get_IRDF(stmt))->rowStatusArray;

--- a/statement.c
+++ b/statement.c
@@ -343,7 +343,7 @@ PGAPI_FreeStmt(HSTMT hstmt,
 void
 InitializeStatementOptions(StatementOptions *opt)
 {
-	memset(opt, 0, sizeof(StatementOptions));
+	pg_memset(opt, 0, sizeof(StatementOptions));
 	opt->scroll_concurrency = SQL_CONCUR_READ_ONLY;
 	opt->cursor_type = SQL_CURSOR_FORWARD_ONLY;
 	opt->retrieve_data = SQL_RD_ON;
@@ -444,7 +444,7 @@ SC_Constructor(ConnectionClass *conn)
 		rv->cancel_info = 0;
 
 		/* Clear Statement Options -- defaults will be set in AllocStmt */
-		memset(&rv->options, 0, sizeof(StatementOptions));
+		pg_memset(&rv->options, 0, sizeof(StatementOptions));
 		InitializeEmbeddedDescriptor((DescriptorClass *)&(rv->ardi),
 				rv, SQL_ATTR_APP_ROW_DESC);
 		InitializeEmbeddedDescriptor((DescriptorClass *)&(rv->apdi),
@@ -470,7 +470,7 @@ SC_Constructor(ConnectionClass *conn)
 		rv->use_server_side_prepare = conn->connInfo.use_server_side_prepare;
 		rv->lock_CC_for_rb = FALSE;
 		// for batch execution
-		memset(&rv->stmt_deferred, 0, sizeof(rv->stmt_deferred));
+		pg_memset(&rv->stmt_deferred, 0, sizeof(rv->stmt_deferred));
 		if ((rv->batch_size = conn->connInfo.batch_size) < 1)
 			rv->batch_size = 1;
 		rv->exec_type = DIRECT_EXEC;
@@ -1250,7 +1250,7 @@ SC_clear_error(StatementClass *self)
 		res->sqlstate[0] = '\0';
 	}
 	self->stmt_time = 0;
-	memset(&self->localtime, 0, sizeof(self->localtime));
+	pg_memset(&self->localtime, 0, sizeof(self->localtime));
 	self->localtime.tm_sec = -1;
 	SC_unref_CC_error(self);
 }
@@ -1412,7 +1412,7 @@ SC_create_errorinfo(const StatementClass *self, PG_ErrorInfo *pgerror_fail_safe)
 	{
 		if (pgerror_fail_safe)
 		{
-			memset(pgerror_fail_safe, 0, sizeof(*pgerror_fail_safe));
+			pg_memset(pgerror_fail_safe, 0, sizeof(*pgerror_fail_safe));
 			pgerror = pgerror_fail_safe;
 			pgerror->status = self->__error_number;
 			STRCPY_FIXED(pgerror->__error_message, ermsg);
@@ -3261,7 +3261,7 @@ PG_BM	SC_Resolve_bookmark(const ARDFields *opts, Int4 idx)
 	bookmark = opts->bookmark;
 	offset = opts->row_offset_ptr ? *(opts->row_offset_ptr) : 0;
 	bind_size = opts->bind_size;
-	memset(&pg_bm, 0, sizeof(pg_bm));
+	pg_memset(&pg_bm, 0, sizeof(pg_bm));
 	if (used = bookmark->used, used != NULL)
 	{
 		used = LENADDR_SHIFT(used, offset);
@@ -3291,7 +3291,7 @@ int	SC_Create_bookmark(StatementClass *self, BindInfoClass *bookmark, Int4 bind_
 	PG_BM		pg_bm;
 
 MYLOG(0, "entering type=%d buflen=" FORMAT_LEN " buf=%p\n", bookmark->returntype, bookmark->buflen, bookmark->buffer);
-	memset(&pg_bm, 0, sizeof(pg_bm));
+	pg_memset(&pg_bm, 0, sizeof(pg_bm));
 	if (SQL_C_BOOKMARK == bookmark->returntype)
 		;
 	else if (bookmark->buflen >= sizeof(pg_bm))

--- a/test/RegisterRegdsn.c
+++ b/test/RegisterRegdsn.c
@@ -45,7 +45,7 @@ static int inst_driver(const char *driver, const char *pathIn, const char *key_v
 	WORD	cbMsg;
 	char	*psz, *pchr;
 
-	memset(szDriver, 0, sizeof(szDriver));
+	SecureZeroMemory(szDriver, sizeof(szDriver));
 	psz = szDriver;
 	strncpy(szDriver, driver, sizeof(szDriver));
 	pcnt = strlen(psz) + 1;
@@ -93,7 +93,7 @@ static int add_dsn(const char *driver, const char *dsn, const char *key_value_pa
 	char	*psz, *pchr;
 	size_t	pcnt;
 
-	memset(szDsn, 0, sizeof(szDsn));
+	SecureZeroMemory(szDsn, sizeof(szDsn));
 	psz = szDsn;
 	_snprintf(psz, sizeof(szDsn), "DSN=%s", dsn);
 	pcnt = strlen(psz) + 1;

--- a/test/src/bulkoperations-test.c
+++ b/test/src/bulkoperations-test.c
@@ -52,8 +52,8 @@ int main(int argc, char **argv)
 	SQLLEN		indColvalues1[3];
 	SQLLEN		indColvalues2[3];
 
-	memset(bookmark, 0x7F, sizeof(bookmark));
-	memset(saved_bookmarks, 0xF7, sizeof(saved_bookmarks));
+	pg_memset(bookmark, 0x7F, sizeof(bookmark));
+	pg_memset(saved_bookmarks, 0xF7, sizeof(saved_bookmarks));
 
 	test_connect_ext("UpdatableCursors=1;Fetch=1");
 

--- a/test/src/common.h
+++ b/test/src/common.h
@@ -19,7 +19,10 @@
 
 #ifdef WIN32
 #define snprintf _snprintf
-#endif
+#define pg_memset(dest, ch, count)  SecureZeroMemory(dest, count)
+#else
+#define pg_memset(dest, ch, count)	memset_s(dest, count, ch, count)
+#endif /* WIN32 */
 
 extern SQLHENV env;
 extern SQLHDBC conn;

--- a/test/src/diagnostic-test.c
+++ b/test/src/diagnostic-test.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 	/*
 	 * Test a very long error message.
 	 */
-	memset(buf, 'x', sizeof(buf) - 10);
+	pg_memset(buf, 'x', sizeof(buf) - 10);
 	sprintf(buf + sizeof(buf) - 10, "END");
 	rc = SQLExecDirect(hstmt, (SQLCHAR *) buf, SQL_NTS);
 	print_diag("SQLExecDirect", SQL_HANDLE_STMT, hstmt);

--- a/test/src/numeric-test.c
+++ b/test/src/numeric-test.c
@@ -33,7 +33,7 @@ build_numeric_struct(SQL_NUMERIC_STRUCT *numericparam,
 	int			len;
 
 	/* parse the hex-encoded value */
-	memset(numericparam, 0, sizeof(SQL_NUMERIC_STRUCT));
+	pg_memset(numericparam, 0, sizeof(SQL_NUMERIC_STRUCT));
 
 	numericparam->sign = sign;
 	numericparam->precision = precision;

--- a/test/src/odbc-escapes-test.c
+++ b/test/src/odbc-escapes-test.c
@@ -142,14 +142,14 @@ static void	escape_test(HSTMT hstmt)
 	executeQuery(hstmt);
 
 	prepareQuery(hstmt, "{ ? = call length('foo') }");
-	memset(outbuf1, 0, sizeof(outbuf1));
+	pg_memset(outbuf1, 0, sizeof(outbuf1));
 	bindOutParamString(hstmt, 1, NULL, outbuf1, sizeof(outbuf1) - 1, 0);
 	executeQuery(hstmt);
 	printf("OUT param: %s\n", outbuf1);
 
 	/* It's preferable to cast VARIADIC any fields */
 	prepareQuery(hstmt, "{ ? = call concat(?::text, ?::text) }");
-	memset(outbuf1, 0, sizeof(outbuf1));
+	pg_memset(outbuf1, 0, sizeof(outbuf1));
 	bindOutParamString(hstmt, 1, NULL, outbuf1, sizeof(outbuf1) - 1, 0);
 	bindParamString(hstmt, 2, NULL, "foo");
 	bindParamString(hstmt, 3, NULL, "bar");
@@ -172,22 +172,22 @@ static void	escape_test(HSTMT hstmt)
 
 	/**** call procedure with out and i-o parameters ****/
 	prepareQuery(hstmt, "{call a_b_c_d_e(?, ?, ?, ?, ?)}");
-	memset(outbuf1, 0, sizeof(outbuf1));
+	pg_memset(outbuf1, 0, sizeof(outbuf1));
 	bindOutParamString(hstmt, 1, NULL, outbuf1, sizeof(outbuf1) - 1, 0);
 	bindParamString(hstmt, 2, NULL, "2017-02-23 11:34:46");
 	strcpy(outbuf3, "4");
 	bindOutParamString(hstmt, 3, NULL, outbuf3, sizeof(outbuf3) - 1, 1);
 	bindParamString(hstmt, 4, NULL, "3.4");
-	memset(outbuf5, 0, sizeof(outbuf5));
+	pg_memset(outbuf5, 0, sizeof(outbuf5));
 	bindOutParamString(hstmt, 5, NULL, outbuf5, sizeof(outbuf5) - 1, 0);
 	executeQuery(hstmt);
 	printf("OUT params: %s : %s : %s\n", outbuf1, outbuf3, outbuf5);
 
 	/**** call procedure parameters by name (e,a,b,c,d) ****/
 	prepareQuery(hstmt, "{call a_b_c_d_e(?, ?, ?, ?, ?)}");
-	memset(outbuf5, 0, sizeof(outbuf5));
+	pg_memset(outbuf5, 0, sizeof(outbuf5));
 	bindOutParamString(hstmt, 1, "e", outbuf5, sizeof(outbuf5) - 1, 0);
-	memset(outbuf1, 0, sizeof(outbuf1));
+	pg_memset(outbuf1, 0, sizeof(outbuf1));
 	bindOutParamString(hstmt, 2, "a", outbuf1, sizeof(outbuf1) - 1, 0);
 	bindParamString(hstmt, 3, "b", "2017-02-23 11:34:46");
 	strcpy(outbuf3, "4");
@@ -202,9 +202,9 @@ static void	escape_test(HSTMT hstmt)
 	strcpy(outbuf3, "4");
 	bindOutParamString(hstmt, 2, "c", outbuf3, sizeof(outbuf3) - 1, 1);
 	bindParamString(hstmt, 3, "d", "3.4");
-	memset(outbuf5, 0, sizeof(outbuf5));
+	pg_memset(outbuf5, 0, sizeof(outbuf5));
 	bindOutParamString(hstmt, 4, "e", outbuf5, sizeof(outbuf5) - 1, 0);
-	memset(outbuf1, 0, sizeof(outbuf1));
+	pg_memset(outbuf1, 0, sizeof(outbuf1));
 	bindOutParamString(hstmt, 5, "a", outbuf1, sizeof(outbuf1) - 1, 0);
 	executeQuery(hstmt);
 	printf("OUT params: %s : %s : %s\n", outbuf1, outbuf3, outbuf5);

--- a/test/src/result-conversions-test.c
+++ b/test/src/result-conversions-test.c
@@ -476,7 +476,7 @@ test_conversion(const char *pgtype, const char *pgvalue, int sqltype, const char
 	if (resultbuf == NULL)
 		resultbuf = malloc(500);
 
-	memset(resultbuf, 0xFF, 500);
+	pg_memset(resultbuf, 0xFF, 500);
 
 	fixed_len = get_sql_type_size(sqltype);
 	if (fixed_len != -1)


### PR DESCRIPTION
`memset` can be declared as "unsafe" because compiler optimizations could remove it from the program.  This is especially problematic when we rely on it to clear out data containing sensitive information such as password.

This PR changes the calls against for `memset` to `pg_memset` and it does this differently depending on UNIX and Windows. 

UNIX: Change `memset` to use `memset_s`. `memset_s` is guaranteed to not be optimized away by the compiler. 

Windows: Windows cannot use `memset_s` because it is an optional function in C11 and MSVC does not provide an implementation for it. In order to mitigate this, we can use SecureZeroMemory instead.