### PR TITLE
fix: use memset if memset_s is not available

### DIFF
--- a/psqlodbc.h
+++ b/psqlodbc.h
@@ -50,6 +50,12 @@
 #include <stdbool.h>
 #endif /* WIN32 */
 
+/* For memset_s */
+#ifdef __STDC_LIB_EXT1__
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <string.h>
+#endif /* __STDC_LIB_EXT1__ */
+
 #ifdef  __INCLUDE_POSTGRES_FE_H__ /* currently not defined */
 /*
  *      Unfortunately #including postgres_fe.h causes various trobles.
@@ -134,7 +140,11 @@ void		debug_memory_check(void);
 #ifdef WIN32
 #define pg_memset(dest, ch, count)	SecureZeroMemory(dest, count)
 #else
+#ifdef __STDC_LIB_EXT1__
 #define pg_memset(dest, ch, count)	memset_s(dest, count, ch, count)
+#else
+#define pg_memset(dest, ch, count)	memset(dest, ch, count)
+#endif /* __STDC_LIB_EXT1__ */
 #endif	  /* WIN32 */
 #endif   /* _MEMORY_DEBUG_ */
 

--- a/test/src/bulkoperations-test.c
+++ b/test/src/bulkoperations-test.c
@@ -52,8 +52,8 @@ int main(int argc, char **argv)
 	SQLLEN		indColvalues1[3];
 	SQLLEN		indColvalues2[3];
 
-	pg_memset(bookmark, 0x7F, sizeof(bookmark));
-	pg_memset(saved_bookmarks, 0xF7, sizeof(saved_bookmarks));
+	memset(bookmark, 0x7F, sizeof(bookmark));
+	memset(saved_bookmarks, 0xF7, sizeof(saved_bookmarks));
 
 	test_connect_ext("UpdatableCursors=1;Fetch=1");
 

--- a/test/src/common.h
+++ b/test/src/common.h
@@ -19,10 +19,21 @@
 
 #ifdef WIN32
 #define snprintf _snprintf
+#endif /* WIN32 */
+
+/* use safe memset if available */
+#ifndef pg_memset // May already be defined by psqlodbc.h in some tests
+#ifdef WIN32
 #define pg_memset(dest, ch, count)  SecureZeroMemory(dest, count)
 #else
+#ifdef __STDC_LIB_EXT1__
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <string.h>
 #define pg_memset(dest, ch, count)	memset_s(dest, count, ch, count)
+#endif /* __STDC_LIB_EXT1__ */
+#define pg_memset(dest, ch, count)	memset(dest, ch, count) // default to memset if functionality isn't available
 #endif /* WIN32 */
+#endif /* pg_memset */
 
 extern SQLHENV env;
 extern SQLHDBC conn;

--- a/test/src/common.h
+++ b/test/src/common.h
@@ -19,21 +19,7 @@
 
 #ifdef WIN32
 #define snprintf _snprintf
-#endif /* WIN32 */
-
-/* use safe memset if available */
-#ifndef pg_memset // May already be defined by psqlodbc.h in some tests
-#ifdef WIN32
-#define pg_memset(dest, ch, count)  SecureZeroMemory(dest, count)
-#else
-#ifdef __STDC_LIB_EXT1__
-#define __STDC_WANT_LIB_EXT1__ 1
-#include <string.h>
-#define pg_memset(dest, ch, count)	memset_s(dest, count, ch, count)
-#endif /* __STDC_LIB_EXT1__ */
-#define pg_memset(dest, ch, count)	memset(dest, ch, count) // default to memset if functionality isn't available
-#endif /* WIN32 */
-#endif /* pg_memset */
+#endif
 
 extern SQLHENV env;
 extern SQLHDBC conn;

--- a/test/src/diagnostic-test.c
+++ b/test/src/diagnostic-test.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 	/*
 	 * Test a very long error message.
 	 */
-	pg_memset(buf, 'x', sizeof(buf) - 10);
+	memset(buf, 'x', sizeof(buf) - 10);
 	sprintf(buf + sizeof(buf) - 10, "END");
 	rc = SQLExecDirect(hstmt, (SQLCHAR *) buf, SQL_NTS);
 	print_diag("SQLExecDirect", SQL_HANDLE_STMT, hstmt);

--- a/test/src/numeric-test.c
+++ b/test/src/numeric-test.c
@@ -33,7 +33,7 @@ build_numeric_struct(SQL_NUMERIC_STRUCT *numericparam,
 	int			len;
 
 	/* parse the hex-encoded value */
-	pg_memset(numericparam, 0, sizeof(SQL_NUMERIC_STRUCT));
+	memset(numericparam, 0, sizeof(SQL_NUMERIC_STRUCT));
 
 	numericparam->sign = sign;
 	numericparam->precision = precision;

--- a/test/src/odbc-escapes-test.c
+++ b/test/src/odbc-escapes-test.c
@@ -142,14 +142,14 @@ static void	escape_test(HSTMT hstmt)
 	executeQuery(hstmt);
 
 	prepareQuery(hstmt, "{ ? = call length('foo') }");
-	pg_memset(outbuf1, 0, sizeof(outbuf1));
+	memset(outbuf1, 0, sizeof(outbuf1));
 	bindOutParamString(hstmt, 1, NULL, outbuf1, sizeof(outbuf1) - 1, 0);
 	executeQuery(hstmt);
 	printf("OUT param: %s\n", outbuf1);
 
 	/* It's preferable to cast VARIADIC any fields */
 	prepareQuery(hstmt, "{ ? = call concat(?::text, ?::text) }");
-	pg_memset(outbuf1, 0, sizeof(outbuf1));
+	memset(outbuf1, 0, sizeof(outbuf1));
 	bindOutParamString(hstmt, 1, NULL, outbuf1, sizeof(outbuf1) - 1, 0);
 	bindParamString(hstmt, 2, NULL, "foo");
 	bindParamString(hstmt, 3, NULL, "bar");
@@ -172,22 +172,22 @@ static void	escape_test(HSTMT hstmt)
 
 	/**** call procedure with out and i-o parameters ****/
 	prepareQuery(hstmt, "{call a_b_c_d_e(?, ?, ?, ?, ?)}");
-	pg_memset(outbuf1, 0, sizeof(outbuf1));
+	memset(outbuf1, 0, sizeof(outbuf1));
 	bindOutParamString(hstmt, 1, NULL, outbuf1, sizeof(outbuf1) - 1, 0);
 	bindParamString(hstmt, 2, NULL, "2017-02-23 11:34:46");
 	strcpy(outbuf3, "4");
 	bindOutParamString(hstmt, 3, NULL, outbuf3, sizeof(outbuf3) - 1, 1);
 	bindParamString(hstmt, 4, NULL, "3.4");
-	pg_memset(outbuf5, 0, sizeof(outbuf5));
+	memset(outbuf5, 0, sizeof(outbuf5));
 	bindOutParamString(hstmt, 5, NULL, outbuf5, sizeof(outbuf5) - 1, 0);
 	executeQuery(hstmt);
 	printf("OUT params: %s : %s : %s\n", outbuf1, outbuf3, outbuf5);
 
 	/**** call procedure parameters by name (e,a,b,c,d) ****/
 	prepareQuery(hstmt, "{call a_b_c_d_e(?, ?, ?, ?, ?)}");
-	pg_memset(outbuf5, 0, sizeof(outbuf5));
+	memset(outbuf5, 0, sizeof(outbuf5));
 	bindOutParamString(hstmt, 1, "e", outbuf5, sizeof(outbuf5) - 1, 0);
-	pg_memset(outbuf1, 0, sizeof(outbuf1));
+	memset(outbuf1, 0, sizeof(outbuf1));
 	bindOutParamString(hstmt, 2, "a", outbuf1, sizeof(outbuf1) - 1, 0);
 	bindParamString(hstmt, 3, "b", "2017-02-23 11:34:46");
 	strcpy(outbuf3, "4");
@@ -202,9 +202,9 @@ static void	escape_test(HSTMT hstmt)
 	strcpy(outbuf3, "4");
 	bindOutParamString(hstmt, 2, "c", outbuf3, sizeof(outbuf3) - 1, 1);
 	bindParamString(hstmt, 3, "d", "3.4");
-	pg_memset(outbuf5, 0, sizeof(outbuf5));
+	memset(outbuf5, 0, sizeof(outbuf5));
 	bindOutParamString(hstmt, 4, "e", outbuf5, sizeof(outbuf5) - 1, 0);
-	pg_memset(outbuf1, 0, sizeof(outbuf1));
+	memset(outbuf1, 0, sizeof(outbuf1));
 	bindOutParamString(hstmt, 5, "a", outbuf1, sizeof(outbuf1) - 1, 0);
 	executeQuery(hstmt);
 	printf("OUT params: %s : %s : %s\n", outbuf1, outbuf3, outbuf5);

--- a/test/src/result-conversions-test.c
+++ b/test/src/result-conversions-test.c
@@ -476,7 +476,7 @@ test_conversion(const char *pgtype, const char *pgvalue, int sqltype, const char
 	if (resultbuf == NULL)
 		resultbuf = malloc(500);
 
-	pg_memset(resultbuf, 0xFF, 500);
+	memset(resultbuf, 0xFF, 500);
 
 	fixed_len = get_sql_type_size(sqltype);
 	if (fixed_len != -1)


### PR DESCRIPTION
## Summary
A previous PR (https://github.com/postgresql-interfaces/psqlodbc/pull/105) replaced the instances of memset with memset_s or SecureZeroMemory because there's a chance that compiler may remove these calls during optimization. However, this PR will break builds with compilers that do not have memset_s. `memset_s` was introduced in C11, but it is flagged as optional and many compilers like GCC do not implement this.

For the time being, this commit will re-introduce memset if `memset_s` is not implemented in the compiler by checking `__STDC_LIB_EXT1__`  and defining `__STDC_WANT_LIB_EXT1__` before the needed imports. (reference: https://en.cppreference.com/w/c/string/byte/memset).

This commit also removes the changes in the unit test. `memset` should be safe in the unit tests. (previous implementaiton caused 2 unit tests to fail, (`not ok 9 - result-conversions test output differs``not ok 40 - diagnostic test`) because it used memset with a non-zero value. 

## Testing
Built on:
- Mac M2 
- Windows
- Linux Ubuntu 24

Ran regression test on Windows and tests had same results as mainline prior to 105
