### PR TITLE
fix: revert to memset for pgdebug_memset

### DIFF
--- a/inouealc.c
+++ b/inouealc.c
@@ -245,7 +245,7 @@ void *pgdebug_memset(void *out, int c, size_t len)
 		return NULL;
 	}
 	out_check(out, len, __FUNCTION__);
-	return memset_s(out, len, c, len);
+	return memset(out, c, len);
 }
 
 void debug_memory_check(void)


### PR DESCRIPTION
A previous PR (#105) reverted some changes from (#104) which changes calls to memset_s back to memset due to memset_s not being supported by all compilers. This change reverts memset_s to memset in pgdebug_memset which was a missed change in #105