### PR TITLE
configure: make sure to call AC_CHECK_HEADER_STDBOOL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,9 +28,11 @@ AC_CHECK_SIZEOF([bool], [],
 #include <stdbool.h>
 #endif])
 
+AC_CHECK_HEADER_STDBOOL()
+
 dnl We use <stdbool.h> if we have it and it declares type bool as having
 dnl size 1.  Otherwise, c.h will fall back to declaring bool as unsigned char.
-if test "$ac_cv_header_stdbool_h" = yes -a "$ac_cv_sizeof_bool" = 1; then
+if test "$ac_cv_header_stdbool_h" = yes && test "$ac_cv_sizeof_bool" = 1; then
   AC_DEFINE([PG_USE_STDBOOL], 1,
             [Define to 1 to use <stdbool.h> to define type bool.])
 fi


### PR DESCRIPTION
before using ac_cv_sizeof_bool

It was called after this conditional, so PG_USE_STDBOOL wasn't set even when it should be as shown in at the end of config.log:

  ac_cv_header_stdbool_h=yes
  ac_cv_sizeof_bool=1
  ac_cv_type__Bool=yes
  #define SIZEOF_BOOL 1
  #define HAVE__BOOL 1
  #define HAVE_STDBOOL_H 1

* fixes: https://github.com/postgresql-interfaces/psqlodbc/issues/110 https://github.com/postgresql-interfaces/psqlodbc/issues/94