### PR TITLE
SQLFreeStmt(stmt,SQL_DROP) now returns an error when it's conn has been disconnected.

### DIFF
--- a/odbcapi.c
+++ b/odbcapi.c
@@ -399,6 +399,8 @@ SQLFreeStmt(HSTMT StatementHandle,
 		if (Option == SQL_DROP)
 		{
 			conn = stmt->hdbc;
+			if (!conn || conn->status == CONN_NOT_CONNECTED)
+				return SQL_INVALID_HANDLE;
 			if (conn)
 				ENTER_CONN_CS(conn);
 		}

--- a/odbcapi.c
+++ b/odbcapi.c
@@ -399,10 +399,12 @@ SQLFreeStmt(HSTMT StatementHandle,
 		if (Option == SQL_DROP)
 		{
 			conn = stmt->hdbc;
-			if (!conn || conn->status == CONN_NOT_CONNECTED)
+			if (!conn || (conn->status != CONN_CONNECTED && conn->status != CONN_EXECUTING))
 				return SQL_INVALID_HANDLE;
 			if (conn)
 				ENTER_CONN_CS(conn);
+			if (!conn || (conn->status != CONN_CONNECTED && conn->status != CONN_EXECUTING))
+				return SQL_INVALID_HANDLE;
 		}
 		else
 			ENTER_STMT_CS(stmt);


### PR DESCRIPTION
SQLFreeStmt(stmt, SQL_DROP) now returns an error before trying to free statement resources
when its connection already has been closed.

A crash occurred when the PostgreSQL server terminated and a connection was subsequently attempted from an application when connection pooling by the driver manager was enabled and several pooled connections existed. In such cases, an invalid memory access would occur in ENTER_CONN_CS(conn) in SQLFreeStmt(), or an invalid address free() would be attempted in SC_clear_error() via PGAPI_FreeStmt().

"CC_cleanup()" doing "conn->status = CONN_NOT_CONNECTED" releases all statements belonging to the connection, so this change will probably not cause a resource leak.
