### PR TITLE
fix: use pgfree for libpq mallocs

### DIFF
--- a/dlg_wingui.c
+++ b/dlg_wingui.c
@@ -830,8 +830,10 @@ MYLOG(0, "entering\n");
 
 void *PQconninfoParse(const char *, char **);
 void PQconninfoFree(void *);
+void PQfreemem(void *ptr);
 typedef void *(*PQCONNINFOPARSEPROC)(const char *, char **);
 typedef void (*PQCONNINFOFREEPROC)(void *); 
+typedef void (*PQFREEMEMPROC)(void *);
 static int
 ds_options3_update(HWND hdlg, ConnInfo *ci)
 {
@@ -841,6 +843,7 @@ ds_options3_update(HWND hdlg, ConnInfo *ci)
 	HMODULE	hmodule;
 	PQCONNINFOPARSEPROC	pproc = NULL;
 	PQCONNINFOFREEPROC	fproc = NULL;	
+	PQFREEMEMPROC		fmproc = NULL;
 
 	MYLOG(0, "entering got ci=%p\n", ci);
 
@@ -854,8 +857,10 @@ ds_options3_update(HWND hdlg, ConnInfo *ci)
 			const char *logmsg = "libpq parameter error";
 
 			MessageBox(hdlg, ermsg ? ermsg : "memory over?", logmsg, MB_ICONEXCLAMATION | MB_OK);
-			if (NULL != ermsg)
-				free(ermsg);
+			if (NULL != ermsg) {
+				fmproc = (PQFREEMEMPROC)GetProcAddress(hmodule, "PQfreemem");
+				(*fmproc)(ermsg);
+			}
 			FreeLibrary(hmodule);
 
 			return 1;


### PR DESCRIPTION
## Summary

Uses libqpq's Free for libqpq malloc'd String

## Description

Changes the generic `free()` function for the error message string allocated by `PQconninfoParse(..)` to use libpq's `PQfreemem(..)`

As per [PostgreSQL's libqpq documents](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PQCONNINFOPARSE), when using `PQconninfoParse(..)`:

> ... After processing the options array, free it by passing it to [PQconninfoFree](https://www.postgresql.org/docs/current/libpq-misc.html#LIBPQ-PQCONNINFOFREE). If this is not done, some memory is leaked for each call to [PQconninfoParse](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PQCONNINFOPARSE). **Conversely, if an error occurs and errmsg is not NULL, be sure to free the error string using [PQfreemem](https://www.postgresql.org/docs/current/libpq-misc.html#LIBPQ-PQFREEMEM).**

Additional information on [PQfreemem](https://www.postgresql.org/docs/current/libpq-misc.html#LIBPQ-PQFREEMEM), this change is only needed for Windows
> Frees memory allocated by libpq, particularly [PQescapeByteaConn](https://www.postgresql.org/docs/current/libpq-exec.html#LIBPQ-PQESCAPEBYTEACONN), [PQescapeBytea](https://www.postgresql.org/docs/current/libpq-exec.html#LIBPQ-PQESCAPEBYTEA), [PQunescapeBytea](https://www.postgresql.org/docs/current/libpq-exec.html#LIBPQ-PQUNESCAPEBYTEA), and PQnotifies. **It is particularly important that this function, rather than free(), be used on Microsoft Windows**. This is because allocating memory in a DLL and releasing it in the application works only if multithreaded/single-threaded, release/debug, and static/dynamic flags are the same for the DLL and the application. **On non-Microsoft Windows platforms, this function is the same as the standard library function free().**