### PR TITLE
Revert "fix double free stmt"

### DIFF
--- a/statement.c
+++ b/statement.c
@@ -291,8 +291,6 @@ PGAPI_FreeStmt(HSTMT hstmt,
 				return SQL_ERROR;		/* stmt may be executing a
 										 * transaction */
 			}
-			// remove the connection from the statement
-			stmt->hdbc = NULL;
 		}
 
 		if (stmt->execute_delegate)


### PR DESCRIPTION
Reverts postgresql-interfaces/psqlodbc#115
This breaks premature test