### PR TITLE
Remove __DATE__ from version message

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -1010,7 +1010,7 @@ static char CC_initial_log(ConnectionClass *self, const char *func)
 	const ConnInfo	*ci = &self->connInfo;
 	char	*encoding, vermsg[128];
 
-	snprintf(vermsg, sizeof(vermsg), "Driver Version='%s,%s'"
+	snprintf(vermsg, sizeof(vermsg), "Driver Version='%s'"
 #ifdef	WIN32
 		" linking %d"
 #ifdef	_MT
@@ -1028,7 +1028,7 @@ static char CC_initial_log(ConnectionClass *self, const char *func)
 #endif /* DEBUG */
 		" library"
 #endif /* WIN32 */
-		"\n", POSTGRESDRIVERVERSION, __DATE__
+		"\n", POSTGRESDRIVERVERSION
 #ifdef	_MSC_VER
 		, _MSC_VER
 #endif /* _MSC_VER */


### PR DESCRIPTION
This made the build unreproducible. The Debian package has been patching out this information since 2016, with no ill effects reported.