### PR TITLE
bug causing out-of-bounds memory access in AddUpdated when updating cached row status

### DIFF
--- a/results.c
+++ b/results.c
@@ -2691,7 +2691,7 @@ MYLOG(DETAIL_LOG_LEVEL, "entering index=" FORMAT_LEN "\n", index);
 		res->updated_keyset[upd_idx].status = status;
 		if (res->updated_tuples)
 		{
-			tuple = res->added_tuples + num_fields * upd_add_idx;
+			tuple = res->updated_tuples + num_fields * upd_idx;
 			ClearCachedRows(tuple, num_fields, 1);
 		}
 	}


### PR DESCRIPTION
**bug causing out-of-bounds memory access in `AddUpdated()` when updating cached row status.**

In the `else if (upd_idx >= 0)` branch at line 2691, the code updates `res->updated_keyset[upd_idx].status` but then incorrectly accesses `res->added_tuples + num_fields * upd_add_idx` to clear cached data.

When a row's status in the `updated_keyset` array is modified, the corresponding cached tuple data must be invalidated. 
The invariant is: **for any index `i`, the tuple cache entry is stored at `base_array + num_fields * i`**. Since we're modifying `updated_keyset[upd_idx]`, the corresponding tuple cache is at `updated_tuples + num_fields * upd_idx`. 
Using the wrong base array (`added_tuples`) or wrong index (`upd_add_idx = -1`) violates this and produces undefined behavior.

## Fix
```c
tuple = res->updated_tuples + num_fields * upd_idx;
```
