### PR TITLE
 Fix SQLPrimaryKeys to exclude INCLUDE columns from results

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -323,6 +323,7 @@ jobs:
       shell: cmd
       run: |
         dotnet tool install --global wix
+        wix eula accept wix7
         wix extension add --global WixToolset.UI.wixext/6.0.0
 
     - name: Build psqlodbc ${{matrix.variant}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ env:
 
   # PostgreSQL build from source.
   POSTGRESQL_SOURCE_TAG: 'REL_18_STABLE'
-  OPENSSL_VERSION: '3_5_5'
+  OPENSSL_VERSION: '3_5_6'
   PKGCONFIGLITE_VERSION: '0.28-1'
   WINFLEXBISON_VERSION: '2.5.24'
   WORKFLOW_VERSION_POSTGRESQL: '1' # increment to invalidate cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,8 +322,7 @@ jobs:
     - name: Install WiX
       shell: cmd
       run: |
-        dotnet tool install --global wix
-        wix eula accept wix7
+        dotnet tool install --global wix --version "6.*"
         wix extension add --global WixToolset.UI.wixext/6.0.0
 
     - name: Build psqlodbc ${{matrix.variant}}

--- a/info.c
+++ b/info.c
@@ -4055,7 +4055,11 @@ retry_public_schema:
 					" AND ta.attnum operator(pg_catalog.=) i.indkey[ia.attnum-1]"
 					" AND (NOT ta.attisdropped)"
 					" AND (NOT ia.attisdropped)"
-					" AND ic.oid operator(pg_catalog.=) i.indexrelid"
+					" AND ic.oid operator(pg_catalog.=) i.indexrelid");
+				if (PG_VERSION_GE(conn, 11.0))
+					appendPQExpBufferStr(&tables_query,
+					" AND ia.attnum operator(pg_catalog.<=) i.indnkeyatts");
+				appendPQExpBufferStr(&tables_query,
 					" order by ia.attnum");
 				break;
 			case 2:
@@ -4075,8 +4079,12 @@ retry_public_schema:
 					" AND ta.attrelid operator(pg_catalog.=) i.indrelid"
 					" AND ta.attnum operator(pg_catalog.=) i.indkey[ia.attnum-1]"
 					" AND (NOT ta.attisdropped)"
-					" AND (NOT ia.attisdropped)"
-					" order by ia.attnum", eq_string, escTableName, eq_string, pkscm);
+					" AND (NOT ia.attisdropped)", eq_string, escTableName, eq_string, pkscm);
+				if (PG_VERSION_GE(conn, 11.0))
+					appendPQExpBufferStr(&tables_query,
+					" AND ia.attnum operator(pg_catalog.<=) i.indnkeyatts");
+				appendPQExpBufferStr(&tables_query,
+					" order by ia.attnum");
 				break;
 		}
 		if (PQExpBufferDataBroken(tables_query))

--- a/installer/buildInstallers.ps1
+++ b/installer/buildInstallers.ps1
@@ -46,6 +46,9 @@ Param(
 [String]$str_msvcp="msvcp"
 [String]$msrun_ptn="msvcr|vcruntime"
 
+# Accept WiX v7 OSMF EULA
+wix eula accept wix7 2>$null
+
 function msvcrun([int]$runtime_version)
 {
 	[String]$str = if ($runtime_version -lt $ucrt_version) {$str_msvcr} else {$str_vcrun}

--- a/installer/buildInstallers.ps1
+++ b/installer/buildInstallers.ps1
@@ -46,9 +46,6 @@ Param(
 [String]$str_msvcp="msvcp"
 [String]$msrun_ptn="msvcr|vcruntime"
 
-# Accept WiX v7 OSMF EULA
-wix eula accept wix7 2>$null
-
 function msvcrun([int]$runtime_version)
 {
 	[String]$str = if ($runtime_version -lt $ucrt_version) {$str_msvcr} else {$str_vcrun}

--- a/test/expected/primarykeys-include.out
+++ b/test/expected/primarykeys-include.out
@@ -1,0 +1,6 @@
+connected
+Check SQLPrimaryKeys with INCLUDE columns
+Result set:
+contrib_regression	public	pk_include_test	a	1	pk_include_test_pkey
+contrib_regression	public	pk_include_test	b	2	pk_include_test_pkey
+disconnecting

--- a/test/src/primarykeys-include-test.c
+++ b/test/src/primarykeys-include-test.c
@@ -1,0 +1,65 @@
+/*
+ * Test that SQLPrimaryKeys excludes INCLUDE columns.
+ *
+ * A PRIMARY KEY with INCLUDE (PG 11+) should only return the actual
+ * key columns, not the included columns.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "common.h"
+
+int
+main(int argc, char **argv)
+{
+	SQLRETURN	rc;
+	HSTMT		hstmt = SQL_NULL_HSTMT;
+
+	test_connect();
+
+	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn, &hstmt);
+	CHECK_CONN_RESULT(rc, "failed to allocate stmt handle", conn);
+
+	/* INCLUDE clause requires PG >= 11 */
+	if (server_version_lt(conn, 11, 0))
+	{
+		printf("Server version < 11, skipping INCLUDE test\n");
+		test_disconnect();
+		return 0;
+	}
+
+	/* Create table with PK that has INCLUDE columns */
+	rc = SQLExecDirect(hstmt,
+		(SQLCHAR *) "DROP TABLE IF EXISTS pk_include_test", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "DROP TABLE failed", hstmt);
+
+	rc = SQLExecDirect(hstmt,
+		(SQLCHAR *) "CREATE TABLE pk_include_test (a int, b int, c int, d int,"
+		" CONSTRAINT pk_include_test_pkey PRIMARY KEY (a, b) INCLUDE (c, d))",
+		SQL_NTS);
+	CHECK_STMT_RESULT(rc, "CREATE TABLE failed", hstmt);
+
+	rc = SQLFreeStmt(hstmt, SQL_CLOSE);
+	CHECK_STMT_RESULT(rc, "SQLFreeStmt failed", hstmt);
+
+	/* Call SQLPrimaryKeys - should return only a and b, not c or d */
+	printf("Check SQLPrimaryKeys with INCLUDE columns\n");
+	rc = SQLPrimaryKeys(hstmt,
+						NULL, 0,
+						(SQLCHAR *) "public", SQL_NTS,
+						(SQLCHAR *) "pk_include_test", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "SQLPrimaryKeys failed", hstmt);
+	print_result(hstmt);
+
+	rc = SQLFreeStmt(hstmt, SQL_CLOSE);
+	CHECK_STMT_RESULT(rc, "SQLFreeStmt failed", hstmt);
+
+	/* Clean up */
+	rc = SQLExecDirect(hstmt,
+		(SQLCHAR *) "DROP TABLE pk_include_test", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "DROP TABLE failed", hstmt);
+
+	test_disconnect();
+
+	return 0;
+}

--- a/test/tests
+++ b/test/tests
@@ -57,4 +57,5 @@ TESTBINS = exe/connect-test \
 	exe/wchar-char-test \
 	exe/params-batch-exec-test \
 	exe/fetch-refcursors-test \
-	exe/descrec-test
+	exe/descrec-test \
+	exe/primarykeys-include-test


### PR DESCRIPTION
  When a PRIMARY KEY is created with an INCLUDE clause (PostgreSQL 11+),
  SQLPrimaryKeys incorrectly returned both the key columns and the
  included columns. For example, given PRIMARY KEY (a, b) INCLUDE (c, d),
  all four columns were returned instead of just a and b.

  The root cause was that the pg_attribute join on the index relation
  iterated over all index attributes without distinguishing key columns
  from included columns. Fix by adding a filter on i.indnkeyatts when
  connected to PostgreSQL >= 11, which limits results to only the actual
  key attributes. Both query paths in PGAPI_PrimaryKeys are fixed.

  Add a regression test that creates a table with a composite primary key
  using INCLUDE and verifies only the key columns are returned.

fixes #170 