### PR TITLE
Fix stack buffer overflow in getPrecisionPart() (GitHub #173)

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -571,6 +571,8 @@ static int getPrecisionPart(int precision, const char * precPart)
 	if (cpys > fracs)
 		cpys = fracs;
 	memcpy(fraction, precPart, cpys);
+	if (precision > fracs)
+		precision = fracs;
 	fraction[precision] = '\0';
 
 	return pg_atoi(fraction);

--- a/pgapi30.c
+++ b/pgapi30.c
@@ -658,12 +658,15 @@ ARDSetField(DescriptorClass *desc, SQLSMALLINT RecNumber,
 			opts->bindings[row_idx].used = Value;
 			break;
 		case SQL_DESC_OCTET_LENGTH:
+			unbind = FALSE;
 			opts->bindings[row_idx].buflen = CAST_PTR(SQLLEN, Value);
 			break;
 		case SQL_DESC_PRECISION:
+			unbind = FALSE;
 			opts->bindings[row_idx].precision = CAST_PTR(SQLSMALLINT, Value);
 			break;
 		case SQL_DESC_SCALE:
+			unbind = FALSE;
 			opts->bindings[row_idx].scale = CAST_PTR(SQLSMALLINT, Value);
 			break;
 		case SQL_DESC_ALLOC_TYPE: /* read-only */

--- a/test/expected/interval-overflow.out
+++ b/test/expected/interval-overflow.out
@@ -1,0 +1,7 @@
+connected
+Test 1: default precision
+hour=1 min=2 sec=3 frac=123456
+Test 2: precision=20 via ARD
+hour=1 min=2 sec=3 frac=123456000
+ok
+disconnecting

--- a/test/src/interval-overflow-test.c
+++ b/test/src/interval-overflow-test.c
@@ -1,0 +1,98 @@
+/*
+ * Test for getPrecisionPart overflow fix (GitHub issue #173).
+ *
+ * Fetches intervals with fractional seconds to verify the driver
+ * handles interval precision correctly and doesn't overflow the
+ * internal buffer in getPrecisionPart().
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+
+int main(int argc, char **argv)
+{
+	SQLRETURN rc;
+	HSTMT hstmt = SQL_NULL_HSTMT;
+	SQL_INTERVAL_STRUCT iv;
+	SQLLEN ind;
+	SQLHDESC ard;
+
+	test_connect();
+
+	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn, &hstmt);
+	CHECK_STMT_RESULT(rc, "SQLAllocHandle failed", hstmt);
+
+	rc = SQLExecDirect(hstmt, (SQLCHAR *) "SET intervalstyle=postgres", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "SET intervalstyle failed", hstmt);
+	rc = SQLFreeStmt(hstmt, SQL_CLOSE);
+	CHECK_STMT_RESULT(rc, "SQLFreeStmt failed", hstmt);
+
+	/* Test 1: default precision */
+	printf("Test 1: default precision\n");
+	rc = SQLExecDirect(hstmt,
+		(SQLCHAR *) "SELECT '01:02:03.123456'::interval", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "SQLExecDirect failed", hstmt);
+
+	rc = SQLBindCol(hstmt, 1, SQL_C_INTERVAL_HOUR_TO_SECOND,
+					&iv, sizeof(iv), &ind);
+	CHECK_STMT_RESULT(rc, "SQLBindCol failed", hstmt);
+
+	rc = SQLFetch(hstmt);
+	CHECK_STMT_RESULT(rc, "SQLFetch failed", hstmt);
+
+	printf("hour=%d min=%d sec=%d frac=%d\n",
+		   (int) iv.intval.day_second.hour,
+		   (int) iv.intval.day_second.minute,
+		   (int) iv.intval.day_second.second,
+		   (int) iv.intval.day_second.fraction);
+
+	rc = SQLFreeStmt(hstmt, SQL_CLOSE);
+	CHECK_STMT_RESULT(rc, "SQLFreeStmt failed", hstmt);
+	rc = SQLFreeStmt(hstmt, SQL_UNBIND);
+	CHECK_STMT_RESULT(rc, "SQLFreeStmt UNBIND failed", hstmt);
+
+	/*
+	 * Test 2: precision=20 via ARD descriptor override.
+	 * Before the fix for issue #173, getPrecisionPart(20, ...)
+	 * would write past the end of its 10-byte stack buffer.
+	 * With the fix, precision is clamped to 9.
+	 */
+	printf("Test 2: precision=20 via ARD\n");
+	memset(&iv, 0, sizeof(iv));
+
+	rc = SQLExecDirect(hstmt,
+		(SQLCHAR *) "SELECT '01:02:03.123456'::interval", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "SQLExecDirect failed", hstmt);
+
+	rc = SQLBindCol(hstmt, 1, SQL_C_INTERVAL_HOUR_TO_SECOND,
+					&iv, sizeof(iv), &ind);
+	CHECK_STMT_RESULT(rc, "SQLBindCol failed", hstmt);
+
+	/* Override precision to 20 — triggers the clamping fix */
+	rc = SQLGetStmtAttr(hstmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, NULL);
+	CHECK_STMT_RESULT(rc, "SQLGetStmtAttr failed", hstmt);
+
+	rc = SQLSetDescField(ard, 1, SQL_DESC_PRECISION,
+						 (SQLPOINTER) 20, 0);
+	CHECK_STMT_RESULT(rc, "SQLSetDescField PRECISION failed", hstmt);
+
+	rc = SQLFetch(hstmt);
+	CHECK_STMT_RESULT(rc, "SQLFetch failed", hstmt);
+
+	printf("hour=%d min=%d sec=%d frac=%d\n",
+		   (int) iv.intval.day_second.hour,
+		   (int) iv.intval.day_second.minute,
+		   (int) iv.intval.day_second.second,
+		   (int) iv.intval.day_second.fraction);
+
+	rc = SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+	CHECK_STMT_RESULT(rc, "SQLFreeHandle failed", hstmt);
+
+	printf("ok\n");
+
+	test_disconnect();
+
+	return 0;
+}

--- a/test/tests
+++ b/test/tests
@@ -58,4 +58,5 @@ TESTBINS = exe/connect-test \
 	exe/params-batch-exec-test \
 	exe/fetch-refcursors-test \
 	exe/descrec-test \
-	exe/primarykeys-include-test
+	exe/primarykeys-include-test \
+	exe/interval-overflow-test


### PR DESCRIPTION
Clamp precision to the buffer size (9) before writing the NUL terminator in getPrecisionPart(). Previously, a precision value > 9 would write past the end of the local fraction[] buffer, corrupting the stack.

Also fix SQLSetDescField for ARD records: setting SQL_DESC_PRECISION, SQL_DESC_SCALE, or SQL_DESC_OCTET_LENGTH no longer nulls the data buffer. The unbind logic was incorrectly applied to these metadata fields, causing any descriptor precision override to silently unbind the column.

Add interval-overflow regression test that exercises both fixes by fetching an interval with fractional seconds using precision=20 via the ARD.

Fixes Issue #173

Reported by [@jarvis24young](https://github.com/jarvis24young) in [#173](https://github.com/postgresql-interfaces/psqlodbc/issues/173)