### PR TITLE
Validate percent escapes before decoding connection-string values

### DIFF
--- a/dlg_specific.c
+++ b/dlg_specific.c
@@ -1572,6 +1572,7 @@ conv_from_hex(const char *s)
 				y = 0,
 				val;
 
+	/* Callers must ensure that s[1] and s[2] are hex digits. */
 	for (i = 1; i <= 2; i++)
 	{
 		if (s[i] >= 'a' && s[i] <= 'f')
@@ -1585,6 +1586,15 @@ conv_from_hex(const char *s)
 	}
 
 	return y;
+}
+
+static BOOL
+is_valid_percent_encoding(const char *s, size_t len)
+{
+	if (len < 3)
+		return FALSE;
+	return isxdigit((unsigned char) s[1]) &&
+		isxdigit((unsigned char) s[2]);
 }
 
 static pgNAME
@@ -1609,9 +1619,14 @@ decode(const char *in)
 			outs[o++] = ' ';
 		else if (inc == '%')
 		{
-			snprintf(&outs[o], ilen + 1 - o, "%c", conv_from_hex(&in[i]));
-			o++;
-			i += 2;
+			if (is_valid_percent_encoding(&in[i], ilen - i))
+			{
+				snprintf(&outs[o], ilen + 1 - o, "%c", conv_from_hex(&in[i]));
+				o++;
+				i += 2;
+			}
+			else
+				outs[o++] = inc;
 		}
 		else
 			outs[o++] = inc;

--- a/test/expected/percent-decode.out
+++ b/test/expected/percent-decode.out
@@ -1,0 +1,4 @@
+truncated percent: ok
+one hex digit: ok
+non-hex escape: ok
+valid percent escape: ok

--- a/test/src/percent-decode-test.c
+++ b/test/src/percent-decode-test.c
@@ -1,0 +1,75 @@
+/*
+ * Test percent decoding in connection-string values.
+ *
+ * Malformed percent escapes should not be decoded.  Before the fix,
+ * pqopt=application_name=% reached conv_from_hex("%") and triggered
+ * sanitizer-detected undefined behavior while SQLDriverConnect() parsed the
+ * connection string.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "common.h"
+
+static void
+check_pqopt_value(const char *label, const char *application_name)
+{
+	SQLRETURN	rc;
+	SQLHENV		henv = SQL_NULL_HENV;
+	SQLHDBC		hdbc = SQL_NULL_HDBC;
+	SQLCHAR		outstr[256];
+	SQLSMALLINT	outlen = 0;
+	char		connstr[1024];
+
+	snprintf(connstr, sizeof(connstr), "DSN=%s;pqopt=application_name=%s",
+			 get_test_dsn(), application_name);
+
+	rc = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &henv);
+	if (!SQL_SUCCEEDED(rc))
+	{
+		fprintf(stderr, "SQLAllocHandle(SQL_HANDLE_ENV) failed\n");
+		exit(1);
+	}
+
+	rc = SQLSetEnvAttr(henv, SQL_ATTR_ODBC_VERSION,
+					   (SQLPOINTER) SQL_OV_ODBC3, 0);
+	if (!SQL_SUCCEEDED(rc))
+	{
+		print_diag("SQLSetEnvAttr failed", SQL_HANDLE_ENV, henv);
+		exit(1);
+	}
+
+	rc = SQLAllocHandle(SQL_HANDLE_DBC, henv, &hdbc);
+	if (!SQL_SUCCEEDED(rc))
+	{
+		print_diag("SQLAllocHandle(SQL_HANDLE_DBC) failed",
+				   SQL_HANDLE_ENV, henv);
+		exit(1);
+	}
+
+	rc = SQLDriverConnect(hdbc, NULL, (SQLCHAR *) connstr, SQL_NTS,
+						  outstr, sizeof(outstr), &outlen,
+						  SQL_DRIVER_NOPROMPT);
+	if (!SQL_SUCCEEDED(rc))
+	{
+		print_diag("SQLDriverConnect failed", SQL_HANDLE_DBC, hdbc);
+		exit(1);
+	}
+	SQLDisconnect(hdbc);
+
+	SQLFreeHandle(SQL_HANDLE_DBC, hdbc);
+	SQLFreeHandle(SQL_HANDLE_ENV, henv);
+
+	printf("%s: ok\n", label);
+}
+
+int
+main(void)
+{
+	check_pqopt_value("truncated percent", "%");
+	check_pqopt_value("one hex digit", "%A");
+	check_pqopt_value("non-hex escape", "%G1");
+	check_pqopt_value("valid percent escape", "%20");
+
+	return 0;
+}

--- a/test/tests
+++ b/test/tests
@@ -60,4 +60,5 @@ TESTBINS = exe/connect-test \
 	exe/descrec-test \
 	exe/primarykeys-include-test \
 	exe/interval-overflow-test \
-	exe/conn-settings-test
+	exe/conn-settings-test \
+	exe/percent-decode-test


### PR DESCRIPTION
This fixes sanitizer-detected undefined behavior in connection-string percent decoding.

Root cause:
- `decode()` treated every `%` in a connection-string value as the beginning of a `%xx` percent escape.
- It called `conv_from_hex(&in[i])` without first checking that two following hex digits were present.
- For a truncated value such as `pqopt=application_name=%`, `conv_from_hex()` reads the string terminator, computes a negative value, and left-shifts it. UBSan reports this as undefined behavior.

Fix:
- Decode only valid `%xx` escapes where both following characters are hex digits.
- Leave malformed or truncated percent sequences unchanged, preserving compatibility while avoiding undefined behavior.

Regression test:
- Adds `percent-decode-test`, which exercises the public `SQLDriverConnect()` path with `pqopt=application_name=%`, `%A`, `%G1`, and `%20`.
- The test requires `SQLDriverConnect()` to succeed for each case, so it verifies more than just "no crash".

Verification performed under ASan/UBSan:

```bash
cd ~/psqlodbc-build/test
export LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/13/libasan.so
ODBCSYSINI=. ODBCINSTINI=./odbcinst.ini ODBCINI=./odbc.ini \
ASAN_OPTIONS=halt_on_error=1:abort_on_error=1 \
UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
./exe/percent-decode-test
```

Output:

```text
truncated percent: ok
one hex digit: ok
non-hex escape: ok
valid percent escape: ok
```