### PR TITLE
Avoid reading past conn_settings end

### DIFF
--- a/multibyte.c
+++ b/multibyte.c
@@ -196,6 +196,8 @@ check_client_encoding(const pgNAME conn_settings)
 				step++;
 				break;
 		}
+		if ('\0' == *cptr)
+			break;
 	}
 	if (!sptr)
 		return NULL;

--- a/test/expected/conn-settings.out
+++ b/test/expected/conn-settings.out
@@ -1,0 +1,3 @@
+Testing client_encoding extraction at end of ConnSettings...
+connected
+disconnecting

--- a/test/src/conn-settings-test.c
+++ b/test/src/conn-settings-test.c
@@ -1,0 +1,16 @@
+/*
+ * Test connection settings parsing.
+ */
+#include <stdio.h>
+
+#include "common.h"
+
+int
+main(void)
+{
+	printf("Testing client_encoding extraction at end of ConnSettings...\n");
+	test_connect_ext("ConnSettings=set+client_encoding+to+UTF8");
+	test_disconnect();
+
+	return 0;
+}

--- a/test/tests
+++ b/test/tests
@@ -59,4 +59,5 @@ TESTBINS = exe/connect-test \
 	exe/fetch-refcursors-test \
 	exe/descrec-test \
 	exe/primarykeys-include-test \
-	exe/interval-overflow-test
+	exe/interval-overflow-test \
+	exe/conn-settings-test


### PR DESCRIPTION
## Summary

`check_client_encoding()` can read one byte past the end of `conn_settings` when the `client_encoding` assignment is the final command in the string and is not followed by a semicolon.

This patch stops the parser once it has reached the terminating NUL byte, and adds a regression test for a terminal `ConnSettings=set+client_encoding+to+UTF8` value.

## Problem

The parser walks `conn_settings` with a `for` loop whose iteration expression increments `cptr` after each state-machine step. In the value-parsing state, when the value is the last token in the string, the inner scan leaves `cptr` positioned on the string terminator.

Without an explicit stop at that point, the outer `for` loop increments `cptr` once more and the next loop condition evaluates `*cptr` past the end of the allocated string. AddressSanitizer reports this as a heap buffer over-read for connection strings where `client_encoding` appears at the end of `ConnSettings`.

## ASan reproduction before the fix

Using the new regression test against the pre-fix `multibyte.c` (`HEAD^`) in my WSL ASan/UBSan build tree:

`ConnSettings=set+client_encoding+to+UTF8`

The focused suite fails with:

```text
not ok 1 - conn-settings test returned 256
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1
#0 check_client_encoding /home/yjw/psqlodbc-build/multibyte.c:129
#1 CC_initial_log /home/yjw/psqlodbc-build/connection.c:1053
#2 LIBPQ_CC_connect /home/yjw/psqlodbc-build/connection.c:1092
#3 CC_connect /home/yjw/psqlodbc-build/connection.c:1142
#4 PGAPI_DriverConnect /home/yjw/psqlodbc-build/drvconn.c:233
#5 SQLDriverConnect /home/yjw/psqlodbc-build/odbcapi.c:213
#6 test_connect_ext src/common.c:92
#7 main src/conn-settings-test.c:12
```

ASan also identifies the offending address as immediately after the decoded `conn_settings` allocation:

```text
0x503000003a4c is located 0 bytes after 28-byte region [0x503000003a30,0x503000003a4c)
allocated by thread T0 here:
#0 strdup
#1 decode /home/yjw/psqlodbc-build/dlg_specific.c:1635
#2 decode_or_remove_braces /home/yjw/psqlodbc-build/dlg_specific.c:1673
#3 copyConnAttributes /home/yjw/psqlodbc-build/dlg_specific.c:686
#4 dconn_get_attributes /home/yjw/psqlodbc-build/drvconn.c:577
```

## Fix

After each state-machine step, the parser now checks whether `cptr` is on `\0` and breaks out before the `for` loop can advance it past the terminator.

This keeps the existing behavior for semicolon-separated commands intact, including the existing logic that backs up over `;` so the outer loop can process command boundaries consistently.

## Test

Added `conn-settings-test`, which connects with:

`ConnSettings=set+client_encoding+to+UTF8`

This exercises the previously problematic terminal `client_encoding` value without a trailing semicolon.

## Local verification after the fix

- Rebuilt the WSL psqlODBC build tree with `make -j4` under the existing ASan/UBSan/gcov configuration.
- Built the new test binary with `make LIBODBC='-lodbc' exe/conn-settings-test`.
- Ran `./runsuite conn-settings --inputdir=.` and got `ok 1 - conn-settings`.