### PR TITLE
Reject overlong cursor names

### DIFF
--- a/results.c
+++ b/results.c
@@ -5055,6 +5055,7 @@ PGAPI_SetCursorName(HSTMT hstmt,
 {
 	CSTR func = "PGAPI_SetCursorName";
 	StatementClass *stmt = (StatementClass *) hstmt;
+	char	   *cursor_name;
 
 	MYLOG(0, "entering hstmt=%p, szCursor=%p, cbCursorMax=%d\n", hstmt, szCursor, cbCursor);
 
@@ -5064,8 +5065,21 @@ PGAPI_SetCursorName(HSTMT hstmt,
 		return SQL_INVALID_HANDLE;
 	}
 
+	cursor_name = make_string(szCursor, cbCursor, NULL, 0);
+	if (!cursor_name)
+	{
+		SC_set_error(stmt, STMT_NO_MEMORY_ERROR, "No memory available to store cursor name", func);
+		return SQL_ERROR;
+	}
+	if (strlen(cursor_name) > MAX_CURSOR_LEN)
+	{
+		free(cursor_name);
+		SC_set_error(stmt, STMT_INVALID_CURSOR_NAME, "Cursor name exceeds SQL_MAX_CURSOR_NAME_LEN", func);
+		return SQL_ERROR;
+	}
+
 	NULL_THE_NAME(stmt->cursor_name);
-	SET_NAME_DIRECTLY(stmt->cursor_name, make_string(szCursor, cbCursor, NULL, 0));
+	SET_NAME_DIRECTLY(stmt->cursor_name, cursor_name);
 	return SQL_SUCCESS;
 }
 

--- a/test/expected/cursor-name.out
+++ b/test/expected/cursor-name.out
@@ -1,3 +1,6 @@
 connected
 cursor name prefix: SQL_CUR
+max cursor name length: 32
+long cursor name SQLSTATE: 34000
+long cursor name rejected
 disconnecting

--- a/test/src/cursor-name-test.c
+++ b/test/src/cursor-name-test.c
@@ -11,6 +11,9 @@ int main(int argc, char **argv)
 	HSTMT hstmt2 = SQL_NULL_HSTMT;
 	char cursornamebuf[20];
 	SQLSMALLINT cursornamelen;
+	SQLUSMALLINT maxcursorlen;
+	char *longcursorname;
+	SQLCHAR sqlstate[6];
 	char buf[40];
 	SQLLEN ind;
 
@@ -47,6 +50,38 @@ int main(int argc, char **argv)
 	/* Per the ODBC spec, the cursor name should begin with SQL_CUR */
 	cursornamebuf[strlen("SQL_CUR")] = '\0';
 	printf("cursor name prefix: %s\n", cursornamebuf);
+
+	rc = SQLGetInfo(conn, SQL_MAX_CURSOR_NAME_LEN, &maxcursorlen, sizeof(maxcursorlen), NULL);
+	CHECK_CONN_RESULT(rc, "SQLGetInfo SQL_MAX_CURSOR_NAME_LEN failed", conn);
+	printf("max cursor name length: %u\n", maxcursorlen);
+
+	longcursorname = malloc(maxcursorlen + 2);
+	if (!longcursorname)
+	{
+		printf("out of memory\n");
+		exit(1);
+	}
+	memset(longcursorname, 'c', maxcursorlen + 1);
+	longcursorname[maxcursorlen + 1] = '\0';
+	rc = SQLSetCursorName(hstmt, (SQLCHAR *) longcursorname, SQL_NTS);
+	if (SQL_SUCCEEDED(rc))
+	{
+		printf("BUG: accepted cursor name longer than SQL_MAX_CURSOR_NAME_LEN\n");
+		free(longcursorname);
+		exit(1);
+	}
+	rc = SQLGetDiagRec(SQL_HANDLE_STMT, hstmt, 1, sqlstate, NULL, NULL, 0, NULL);
+	CHECK_STMT_RESULT(rc, "SQLGetDiagRec failed", hstmt);
+	if (strcmp((char *) sqlstate, "34000") != 0)
+	{
+		printf("unexpected SQLSTATE for long cursor name: %s\n", sqlstate);
+		free(longcursorname);
+		exit(1);
+	}
+	printf("long cursor name SQLSTATE: %s\n", sqlstate);
+	printf("long cursor name rejected\n");
+	free(longcursorname);
+	SQLFreeStmt(hstmt, SQL_CLOSE);
 
 	/* Use a custom name */
 	rc = SQLSetCursorName(hstmt, (SQLCHAR *) "my_test_cursor", SQL_NTS);


### PR DESCRIPTION
## Summary

This patch makes `SQLSetCursorName()` reject cursor names longer than the length advertised by the driver through `SQLGetInfo(SQL_MAX_CURSOR_NAME_LEN)`.

The driver reports `MAX_CURSOR_LEN` (`32`) for `SQL_MAX_CURSOR_NAME_LEN`, but `PGAPI_SetCursorName()` previously accepted and stored longer application-provided cursor names. The new check validates the fully materialized cursor name before replacing the statement's current cursor name.

## Details

`PGAPI_SetCursorName()` now:

- builds the requested cursor name into a temporary buffer first;
- reports `STMT_NO_MEMORY_ERROR` if allocation fails;
- rejects names longer than `MAX_CURSOR_LEN` with `STMT_INVALID_CURSOR_NAME`;
- only replaces `stmt->cursor_name` after allocation and validation both succeed.

This keeps the statement state unchanged on failure and makes `SQLSetCursorName()` consistent with the driver's advertised ODBC cursor-name limit.

## Regression test

The existing `cursor-name` black-box ODBC test now:

- queries `SQL_MAX_CURSOR_NAME_LEN` from the connected driver;
- builds an invalid cursor name with length `SQL_MAX_CURSOR_NAME_LEN + 1`;
- verifies that `SQLSetCursorName()` rejects it;
- verifies the diagnostic SQLSTATE is `34000`;
- then continues through the existing valid cursor-name path.

Verified in WSL against the unixODBC test path with an ASan/UBSan/gcov build:

```sh
cd ~/psqlodbc-build
make -j4
cd test
make LIBODBC='-lodbc' exe/cursor-name-test
ODBCSYSINI=. ODBCINSTINI=./odbcinst.ini ODBCINI=./odbc.ini \
  ASAN_OPTIONS=verify_asan_link_order=0:detect_leaks=0 \
  LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
  ./runsuite cursor-name --inputdir=.
```

Result:

```text
TAP version 13
1..1
ok 1 - cursor-name
```