### PR TITLE
Handle ARD bookmark allocation failure

### DIFF
--- a/bind.c
+++ b/bind.c
@@ -220,6 +220,12 @@ MYLOG(DETAIL_LOG_LEVEL, "Bind column 0 is type %d not of type SQL_C_BOOKMARK\n",
 			}
 
 			bookmark = ARD_AllocBookmark(opts);
+			if (!bookmark)
+			{
+				SC_set_error(stmt, STMT_NO_MEMORY_ERROR, "Could not allocate memory for bookmark binding.", func);
+				ret = SQL_ERROR;
+				goto cleanup;
+			}
 			bookmark->buffer = rgbValue;
 			bookmark->used =
 			bookmark->indicator = pcbValue;

--- a/descriptor.c
+++ b/descriptor.c
@@ -343,6 +343,8 @@ BindInfoClass	*ARD_AllocBookmark(ARDFields *ardopts)
 	if (!ardopts->bookmark)
 	{
 		ardopts->bookmark = (BindInfoClass *) malloc(sizeof(BindInfoClass));
+		if (!ardopts->bookmark)
+			return NULL;
 		pg_memset(ardopts->bookmark, 0, sizeof(BindInfoClass));
 	}
 	return ardopts->bookmark;

--- a/pgapi30.c
+++ b/pgapi30.c
@@ -563,6 +563,12 @@ ARDSetField(DescriptorClass *desc, SQLSMALLINT RecNumber,
 	{
 		BindInfoClass	*bookmark = ARD_AllocBookmark(opts);
 
+		if (!bookmark)
+		{
+			DC_set_error(desc, DESC_NO_MEMORY_ERROR, "Could not allocate memory for bookmark descriptor");
+			return SQL_ERROR;
+		}
+
 		switch (FieldIdentifier)
 		{
 			case SQL_DESC_TYPE:

--- a/statement.c
+++ b/statement.c
@@ -229,7 +229,14 @@ PGAPI_AllocStmt(HDBC hdbc,
 		InitializeARDFields(&stmt->ardi.ardf);
 	}
 	ardopts = SC_get_ARDF(stmt);
-	ARD_AllocBookmark(ardopts);
+	if (!ARD_AllocBookmark(ardopts))
+	{
+		CC_set_error(conn, CONN_STMT_ALLOC_ERROR, "No more memory to allocate a further SQL-statement", func);
+		CC_remove_statement(conn, stmt);
+		SC_Destructor(stmt);
+		*phstmt = SQL_NULL_HSTMT;
+		return SQL_ERROR;
+	}
 
 	/* Save the handle for later */
 	stmt->phstmt = phstmt;

--- a/test/expected/ard-bookmark-oom.out
+++ b/test/expected/ard-bookmark-oom.out
@@ -1,0 +1,5 @@
+connected
+allocating ARD bookmark during statement allocation
+statement handle allocated
+disconnecting
+ok

--- a/test/src/ard-bookmark-oom-test.c
+++ b/test/src/ard-bookmark-oom-test.c
@@ -1,0 +1,39 @@
+/*
+ * Test ARD bookmark allocation during statement handle allocation.
+ *
+ * This is the normal black-box regression path for the OOM hardening in
+ * ARD_AllocBookmark().  The actual allocation-failure path is validated with
+ * external malloc-failure injection, because the default regression suite must
+ * remain portable and deterministic.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "common.h"
+
+int
+main(void)
+{
+	SQLRETURN	rc;
+	HSTMT		hstmt = SQL_NULL_HSTMT;
+
+	test_connect_ext("UseDeclareFetch=1;Fetch=1");
+
+	printf("allocating ARD bookmark during statement allocation\n");
+	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn, &hstmt);
+	if (!SQL_SUCCEEDED(rc))
+	{
+		print_diag("statement allocation failed", SQL_HANDLE_DBC, conn);
+		test_disconnect();
+		return 1;
+	}
+	printf("statement handle allocated\n");
+
+	rc = SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+	CHECK_STMT_RESULT(rc, "SQLFreeHandle failed", hstmt);
+
+	test_disconnect();
+	printf("ok\n");
+
+	return 0;
+}

--- a/test/tests
+++ b/test/tests
@@ -38,6 +38,7 @@ TESTBINS = exe/connect-test \
 	exe/cursor-name-test \
 	exe/cursor-block-delete-test \
 	exe/bookmark-test \
+	exe/ard-bookmark-oom-test \
 	exe/declare-fetch-commit-test \
 	exe/declare-fetch-block-test \
 	exe/positioned-update-test \


### PR DESCRIPTION
## Summary

This hardens ARD bookmark allocation so low-memory failures are reported as ODBC errors instead of dereferencing a NULL pointer.

`ARD_AllocBookmark()` previously called `malloc(sizeof(BindInfoClass))` and immediately cleared the returned pointer. If the allocation failed, statement allocation or bookmark binding could crash the host process.

The patch:

- returns `NULL` from `ARD_AllocBookmark()` when bookmark allocation fails;
- handles that failure in `PGAPI_AllocStmt()` by removing the partially registered statement, destroying it, clearing the output handle, and returning `SQL_ERROR` with the existing statement allocation diagnostic;
- handles the same failure in `SQLBindCol()` bookmark-column binding with `STMT_NO_MEMORY_ERROR`;
- handles ARD bookmark descriptor field updates with `DESC_NO_MEMORY_ERROR`;
- adds a black-box ODBC regression test for the normal statement-allocation path that initializes the ARD bookmark.

## Validation

Built and tested in WSL against the real driver through unixODBC.

Default regression checks:

```sh
cd ~/psqlodbc-current-oom/test
ODBCSYSINI=. ODBCINSTINI=./odbcinst.ini ODBCINI=./odbc.ini \
  ./runsuite ard-bookmark-oom bookmark bulkoperations --inputdir=.
```

Result:

```text
ok 1 - ard-bookmark-oom
ok 2 - bookmark
ok 3 - bulkoperations
```

Manual OOM fault-injection validation with the real driver:

```sh
PODBC_FAIL_MALLOC_SIZE=40 PODBC_FAIL_MALLOC_N=178 \
LD_PRELOAD=./exe/malloc_fail_shim.so \
ODBCSYSINI=. ODBCINSTINI=./odbcinst.ini ODBCINI=./odbc.ini \
  ./exe/ard-bookmark-oom-bugwatch-test
```

Before the fix this produced `Segmentation fault (core dumped)` at `descriptor.c:345` via `statement.c:232`.

After the fix it returns a normal ODBC allocation error without crashing:

```text
SQLAllocHandle stmt rc=-1 hstmt=(nil)
HY001=No more memory to allocate a further SQL-statement
statement allocation returned an error without crashing
```

The LD_PRELOAD fault-injection harness is not registered in the portable regression suite; the committed regression test covers the public ODBC statement-allocation path under normal conditions.