### PR TITLE
Reject invalid SQLPutData lengths

### DIFF
--- a/execute.c
+++ b/execute.c
@@ -1673,8 +1673,14 @@ PGAPI_PutData(HSTMT hstmt,
 	}
 	if (!lenset)
 	{
-		if (cbValue < 0)
+		if (cbValue == SQL_NULL_DATA || cbValue == SQL_DEFAULT_PARAM)
 			putlen = cbValue;
+		else if (cbValue < 0)
+		{
+			SC_set_error(stmt, STMT_INVALID_ARGUMENT_NO, "Invalid string or buffer length", func);
+			retval = SQL_ERROR;
+			goto cleanup;
+		}
 		else
 #ifdef	UNICODE_SUPPORT
 		if (ctype == SQL_C_CHAR || ctype == SQL_C_BINARY || ctype == SQL_C_WCHAR)
@@ -1714,7 +1720,7 @@ PGAPI_PutData(HSTMT hstmt,
 
 		*current_pdata->EXEC_used = putlen;
 
-		if (cbValue == SQL_NULL_DATA)
+		if (cbValue == SQL_NULL_DATA || cbValue == SQL_DEFAULT_PARAM)
 		{
 			retval = SQL_SUCCESS;
 			goto cleanup;
@@ -1779,6 +1785,13 @@ PGAPI_PutData(HSTMT hstmt,
 	{
 		/* calling SQLPutData more than once */
 		MYLOG(0, "(>1) cbValue = " FORMAT_LEN "\n", cbValue);
+
+		if (*current_pdata->EXEC_used < 0)
+		{
+			SC_set_error(stmt, STMT_SEQUENCE_ERROR, "Cannot append data after a null or default parameter indicator", func);
+			retval = SQL_ERROR;
+			goto cleanup;
+		}
 
 		/* if (current_iparam->SQLType == SQL_LONGVARBINARY) */
 		if (handling_lo)

--- a/test/expected/dataatexecution.out
+++ b/test/expected/dataatexecution.out
@@ -8,4 +8,6 @@ Fetching result sets for array bound (2 results expected)
 4
 2: Result set:
 5
+Invalid SQLPutData length rejected
+SQLPutData append after null rejected
 disconnecting

--- a/test/src/dataatexecution-test.c
+++ b/test/src/dataatexecution-test.c
@@ -15,6 +15,10 @@ int main(int argc, char **argv)
 	SQLLEN str_ind_array[2];
 	SQLUSMALLINT status_array[2];
 	SQLULEN nprocessed = 0;
+	SQLCHAR sqlstate[6];
+	SQLCHAR message[256];
+	SQLINTEGER nativeerror;
+	SQLSMALLINT textlen;
 	int i;
 
 	test_connect();
@@ -186,6 +190,111 @@ int main(int argc, char **argv)
 	}
 	if (rc != SQL_NO_DATA)
 		CHECK_STMT_RESULT(rc, "SQLMoreResults failed", hstmt);
+
+	rc = SQLFreeStmt(hstmt, SQL_CLOSE);
+	CHECK_STMT_RESULT(rc, "SQLFreeStmt failed", hstmt);
+
+	/****
+	 * Reject invalid negative lengths in SQLPutData.  Only ODBC sentinel
+	 * values such as SQL_NULL_DATA, SQL_DEFAULT_PARAM, and SQL_NTS are
+	 * valid negative values.
+	 */
+
+	cbParam1 = SQL_DATA_AT_EXEC;
+	rc = SQLPrepare(hstmt, (SQLCHAR *) "SELECT id FROM byteatab WHERE t = ?", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "SQLPrepare failed", hstmt);
+
+	rc = SQLBindParameter(hstmt, 1, SQL_PARAM_INPUT,
+						  SQL_C_BINARY,	/* value type */
+						  SQL_VARBINARY, /* param type */
+						  3,			/* column size */
+						  0,			/* dec digits */
+						  (void *) 1,	/* param value ptr. For a data-at-exec
+										 * param, this is "parameter id" */
+						  0,			/* buffer len */
+						  &cbParam1		/* StrLen_or_IndPtr */);
+	CHECK_STMT_RESULT(rc, "SQLBindParameter failed", hstmt);
+
+	rc = SQLExecute(hstmt);
+	if (rc != SQL_NEED_DATA)
+		CHECK_STMT_RESULT(rc, "SQLExecute failed", hstmt);
+
+	paramid = 0;
+	rc = SQLParamData(hstmt, &paramid);
+	if (rc != SQL_NEED_DATA || paramid != (void *) 1)
+	{
+		printf("SQLParamData didn't request the invalid-length parameter\n");
+		exit(1);
+	}
+
+	rc = SQLPutData(hstmt, "bad", -10);
+	if (rc != SQL_ERROR)
+	{
+		printf("SQLPutData accepted an invalid negative length\n");
+		exit(1);
+	}
+	rc = SQLGetDiagRec(SQL_HANDLE_STMT, hstmt, 1, sqlstate, &nativeerror,
+					   message, sizeof(message), &textlen);
+	if (!SQL_SUCCEEDED(rc) || strcmp((char *) sqlstate, "HY024") != 0)
+	{
+		printf("SQLPutData returned unexpected SQLSTATE: %s\n", SQL_SUCCEEDED(rc) ? (char *) sqlstate : "<none>");
+		exit(1);
+	}
+	printf("Invalid SQLPutData length rejected\n");
+
+	rc = SQLFreeStmt(hstmt, SQL_CLOSE);
+	CHECK_STMT_RESULT(rc, "SQLFreeStmt failed", hstmt);
+
+	/****
+	 * Once a data-at-execution parameter is marked as NULL, reject later
+	 * chunks for the same parameter instead of treating the negative
+	 * indicator as an append offset.
+	 */
+
+	cbParam1 = SQL_DATA_AT_EXEC;
+	rc = SQLPrepare(hstmt, (SQLCHAR *) "SELECT id FROM byteatab WHERE t = ?", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "SQLPrepare failed", hstmt);
+
+	rc = SQLBindParameter(hstmt, 1, SQL_PARAM_INPUT,
+						  SQL_C_BINARY,	/* value type */
+						  SQL_VARBINARY, /* param type */
+						  3,			/* column size */
+						  0,			/* dec digits */
+						  (void *) 1,	/* param value ptr. For a data-at-exec
+										 * param, this is "parameter id" */
+						  0,			/* buffer len */
+						  &cbParam1		/* StrLen_or_IndPtr */);
+	CHECK_STMT_RESULT(rc, "SQLBindParameter failed", hstmt);
+
+	rc = SQLExecute(hstmt);
+	if (rc != SQL_NEED_DATA)
+		CHECK_STMT_RESULT(rc, "SQLExecute failed", hstmt);
+
+	paramid = 0;
+	rc = SQLParamData(hstmt, &paramid);
+	if (rc != SQL_NEED_DATA || paramid != (void *) 1)
+	{
+		printf("SQLParamData didn't request the null parameter\n");
+		exit(1);
+	}
+
+	rc = SQLPutData(hstmt, NULL, SQL_NULL_DATA);
+	CHECK_STMT_RESULT(rc, "SQLPutData(SQL_NULL_DATA) failed", hstmt);
+
+	rc = SQLPutData(hstmt, "x", 1);
+	if (rc != SQL_ERROR)
+	{
+		printf("SQLPutData accepted append after SQL_NULL_DATA\n");
+		exit(1);
+	}
+	rc = SQLGetDiagRec(SQL_HANDLE_STMT, hstmt, 1, sqlstate, &nativeerror,
+					   message, sizeof(message), &textlen);
+	if (!SQL_SUCCEEDED(rc) || strcmp((char *) sqlstate, "HY010") != 0)
+	{
+		printf("SQLPutData append-after-null returned unexpected SQLSTATE: %s\n", SQL_SUCCEEDED(rc) ? (char *) sqlstate : "<none>");
+		exit(1);
+	}
+	printf("SQLPutData append after null rejected\n");
 
 	rc = SQLFreeStmt(hstmt, SQL_CLOSE);
 	CHECK_STMT_RESULT(rc, "SQLFreeStmt failed", hstmt);


### PR DESCRIPTION
## Summary

This patch hardens `SQLPutData()` data-at-execution handling against invalid negative `StrLen_or_Ind` values.

`PGAPI_PutData()` previously treated any negative `cbValue` as a length and stored it in `EXEC_used`. That value is later used as the append offset for repeated `SQLPutData()` calls. A caller that supplies an invalid negative length can therefore leave a negative offset in the put-data state, and a subsequent positive chunk can reach the append path with that negative offset.

The updated fix keeps the error handling within the existing statement error-code set, per review feedback:

- accepts the ODBC sentinel values `SQL_NULL_DATA` and `SQL_DEFAULT_PARAM`
- keeps existing `SQL_NTS` handling for character data
- rejects other negative lengths using the existing `STMT_INVALID_ARGUMENT_NO` statement error
- treats `SQL_DEFAULT_PARAM` like `SQL_NULL_DATA` on the first put-data call so it does not fall through to allocation/copy logic with a negative length
- rejects later chunks after a null/default indicator before the LO/non-LO split using the existing `STMT_SEQUENCE_ERROR`

This keeps invalid API input from becoming persistent statement state and prevents it from being reused as a buffer offset, without adding new statement error enums or changing the connection/environment diagnostic paths.

## Tests

Added regression coverage to `dataatexecution-test` for two public ODBC API paths:

```c
SQLPutData(hstmt, "bad", -10);
```

verifies `SQL_ERROR` with the existing `HY024` diagnostic, and:

```c
SQLPutData(hstmt, NULL, SQL_NULL_DATA);
SQLPutData(hstmt, "x", 1);
```

verifies `SQL_ERROR` with the existing `HY010` diagnostic.

Verified in WSL with a clean build copy:

```text
cd ~/psqlodbc-pr182-review
./bootstrap
./configure --with-unixodbc=__without_odbc_config \
  CFLAGS='-O1 -g -fno-omit-frame-pointer -I/usr/include/postgresql -DSQLCOLATTRIBUTE_SQLLEN -Wall'
make -j2
cd test
make reset-db LIBODBC=-lodbc
make exe/dataatexecution-test LIBODBC=-lodbc
ODBCSYSINI=. ODBCINSTINI=./odbcinst.ini ODBCINI=./odbc.ini ./reset-db < sampletables.sql
ODBCSYSINI=. ODBCINSTINI=./odbcinst.ini ODBCINI=./odbc.ini ./exe/dataatexecution-test
```

Observed output:

```text
connected
Result set:
2
3
Parameter	Status
Fetching result sets for array bound (2 results expected)
1: Result set:
4
2: Result set:
5
Invalid SQLPutData length rejected
SQLPutData append after null rejected
disconnecting
```
