### PR TITLE
Detach freed app descriptors from statements

### DIFF
--- a/descriptor.c
+++ b/descriptor.c
@@ -384,6 +384,29 @@ char CC_add_descriptor(ConnectionClass *self, DescriptorClass *desc)
 	return TRUE;
 }
 
+static void
+CC_detach_descriptor(ConnectionClass *conn, const DescriptorClass *desc)
+{
+	int	i;
+
+	if (!conn || !desc)
+		return;
+
+	CONNLOCK_ACQUIRE(conn);
+	for (i = 0; i < conn->num_stmts; i++)
+	{
+		StatementClass	*stmt = conn->stmts[i];
+
+		if (!stmt)
+			continue;
+		if (stmt->ard == desc)
+			stmt->ard = &(stmt->ardi);
+		if (stmt->apd == desc)
+			stmt->apd = &(stmt->apdi);
+	}
+	CONNLOCK_RELEASE(conn);
+}
+
 /*
  *	This API allocates a Application descriptor.
  */
@@ -424,14 +447,17 @@ RETCODE SQL_API
 PGAPI_FreeDesc(SQLHDESC DescriptorHandle)
 {
 	DescriptorClass *desc = (DescriptorClass *) DescriptorHandle;
+	const char	embedded = desc->deschd.embedded;
+	ConnectionClass	*conn = DC_get_conn(desc);
 	RETCODE	ret = SQL_SUCCESS;
 
 	MYLOG(0, "entering...\n");
+	if (!embedded)
+		CC_detach_descriptor(conn, desc);
 	DC_Destructor(desc);
-	if (!desc->deschd.embedded)
+	if (!embedded)
 	{
 		int	i;
-		ConnectionClass	*conn = DC_get_conn(desc);
 
 		for (i = 0; i < conn->num_descs; i++)
 		{

--- a/test/expected/descriptors-free.out
+++ b/test/expected/descriptors-free.out
@@ -1,0 +1,4 @@
+connected
+freeing attached application row descriptor
+freeing attached application parameter descriptor
+disconnecting

--- a/test/src/descriptors-free-test.c
+++ b/test/src/descriptors-free-test.c
@@ -1,0 +1,142 @@
+/*
+ * Test freeing explicitly attached application descriptors.
+ *
+ * A statement must not keep dangling ARD/APD pointers after an application
+ * descriptor is freed.  The driver should fall back to the statement's
+ * implicit descriptors so later statement attributes can still be changed.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "common.h"
+
+static HSTMT
+alloc_stmt(void)
+{
+	HSTMT		hstmt = SQL_NULL_HSTMT;
+	SQLRETURN	rc;
+
+	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn, &hstmt);
+	if (!SQL_SUCCEEDED(rc))
+	{
+		print_diag("SQLAllocHandle(SQL_HANDLE_STMT) failed",
+			SQL_HANDLE_DBC, conn);
+		exit(1);
+	}
+	return hstmt;
+}
+
+static SQLHDESC
+alloc_desc(void)
+{
+	SQLHDESC	hdesc = SQL_NULL_HDESC;
+	SQLRETURN	rc;
+
+	rc = SQLAllocHandle(SQL_HANDLE_DESC, conn, &hdesc);
+	if (!SQL_SUCCEEDED(rc))
+	{
+		print_diag("SQLAllocHandle(SQL_HANDLE_DESC) failed",
+			SQL_HANDLE_DBC, conn);
+		exit(1);
+	}
+	return hdesc;
+}
+
+static void
+test_app_row_desc_free(void)
+{
+	HSTMT		hstmt = alloc_stmt();
+	SQLHDESC	hdesc = alloc_desc();
+	SQLHDESC	current = SQL_NULL_HDESC;
+	SQLRETURN	rc;
+
+	printf("freeing attached application row descriptor\n");
+	rc = SQLSetStmtAttr(hstmt, SQL_ATTR_APP_ROW_DESC, hdesc,
+		SQL_IS_POINTER);
+	CHECK_STMT_RESULT(rc, "attach ARD failed", hstmt);
+
+	rc = SQLGetStmtAttr(hstmt, SQL_ATTR_APP_ROW_DESC, &current, 0, NULL);
+	CHECK_STMT_RESULT(rc, "get attached ARD failed", hstmt);
+	if (current != hdesc)
+	{
+		printf("attached ARD handle mismatch\n");
+		exit(1);
+	}
+
+	rc = SQLFreeHandle(SQL_HANDLE_DESC, hdesc);
+	if (!SQL_SUCCEEDED(rc))
+	{
+		printf("SQLFreeHandle(SQL_HANDLE_DESC) for ARD failed\n");
+		exit(1);
+	}
+
+	rc = SQLGetStmtAttr(hstmt, SQL_ATTR_APP_ROW_DESC, &current, 0, NULL);
+	CHECK_STMT_RESULT(rc, "get ARD after free failed", hstmt);
+	if (current == hdesc)
+	{
+		printf("freed ARD is still attached to the statement\n");
+		exit(1);
+	}
+
+	rc = SQLSetStmtAttr(hstmt, SQL_ATTR_ROW_ARRAY_SIZE,
+		(SQLPOINTER) 2, 0);
+	CHECK_STMT_RESULT(rc, "set row array size after ARD free failed", hstmt);
+
+	rc = SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+	CHECK_STMT_RESULT(rc, "free ARD test statement failed", hstmt);
+}
+
+static void
+test_app_param_desc_free(void)
+{
+	HSTMT		hstmt = alloc_stmt();
+	SQLHDESC	hdesc = alloc_desc();
+	SQLHDESC	current = SQL_NULL_HDESC;
+	SQLRETURN	rc;
+
+	printf("freeing attached application parameter descriptor\n");
+	rc = SQLSetStmtAttr(hstmt, SQL_ATTR_APP_PARAM_DESC, hdesc,
+		SQL_IS_POINTER);
+	CHECK_STMT_RESULT(rc, "attach APD failed", hstmt);
+
+	rc = SQLGetStmtAttr(hstmt, SQL_ATTR_APP_PARAM_DESC, &current, 0, NULL);
+	CHECK_STMT_RESULT(rc, "get attached APD failed", hstmt);
+	if (current != hdesc)
+	{
+		printf("attached APD handle mismatch\n");
+		exit(1);
+	}
+
+	rc = SQLFreeHandle(SQL_HANDLE_DESC, hdesc);
+	if (!SQL_SUCCEEDED(rc))
+	{
+		printf("SQLFreeHandle(SQL_HANDLE_DESC) for APD failed\n");
+		exit(1);
+	}
+
+	rc = SQLGetStmtAttr(hstmt, SQL_ATTR_APP_PARAM_DESC, &current, 0, NULL);
+	CHECK_STMT_RESULT(rc, "get APD after free failed", hstmt);
+	if (current == hdesc)
+	{
+		printf("freed APD is still attached to the statement\n");
+		exit(1);
+	}
+
+	rc = SQLSetStmtAttr(hstmt, SQL_ATTR_PARAMSET_SIZE,
+		(SQLPOINTER) 2, 0);
+	CHECK_STMT_RESULT(rc, "set paramset size after APD free failed", hstmt);
+
+	rc = SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+	CHECK_STMT_RESULT(rc, "free APD test statement failed", hstmt);
+}
+
+int
+main(int argc, char **argv)
+{
+	test_connect();
+	test_app_row_desc_free();
+	test_app_param_desc_free();
+	test_disconnect();
+	return 0;
+}

--- a/test/tests
+++ b/test/tests
@@ -59,6 +59,7 @@ TESTBINS = exe/connect-test \
 	exe/params-batch-exec-test \
 	exe/fetch-refcursors-test \
 	exe/descrec-test \
+	exe/descriptors-free-test \
 	exe/primarykeys-include-test \
 	exe/interval-overflow-test \
 	exe/conn-settings-test \


### PR DESCRIPTION
Fix a dangling application descriptor reference left on statements after
SQLFreeHandle(SQL_HANDLE_DESC).

When an application descriptor is attached through SQL_ATTR_APP_ROW_DESC or
SQL_ATTR_APP_PARAM_DESC, the statement stores the descriptor pointer directly.
PGAPI_FreeDesc() removed and freed the descriptor from the connection descriptor
list, but did not reset statements still pointing at it. A later statement
attribute write through SC_get_ARDF()/SC_get_APDF() can therefore access freed
memory.

The fix detaches a non-embedded descriptor from all statements on the same
connection before destroying it. Statements are reset to their implicit ARD/APD.

The new regression test covers both descriptor classes:

- attach an application row descriptor, free it, then set SQL_ATTR_ROW_ARRAY_SIZE
- attach an application parameter descriptor, free it, then set SQL_ATTR_PARAMSET_SIZE
- verify SQLGetStmtAttr no longer returns the freed descriptor handle

Verification performed in WSL with ASan/UBSan:

```text
# vulnerable build, minimal public-API reproducer
ERROR: AddressSanitizer: heap-use-after-free
WRITE of size 8
#0 PGAPI_SetStmtAttr pgapi30.c:2491
#1 SQLSetStmtAttr odbcapi30.c:698
freed by:
#1 PGAPI_FreeDesc descriptor.c:442
#2 SQLFreeHandle odbcapi30.c:291
```

After this patch, from a clean clone of this branch:

```text
./bootstrap
./configure --with-unixodbc=__without_odbc_config \
  CFLAGS='-O1 -g -fno-omit-frame-pointer -fsanitize=address,undefined -I/usr/include/postgresql -DSQLCOLATTRIBUTE_SQLLEN -Wall' \
  LDFLAGS='-fsanitize=address,undefined'
make -j2
cd test
make exe/descriptors-free-test LIBODBC=-lodbc
ASAN_OPTIONS=detect_leaks=0:halt_on_error=1:abort_on_error=1 \
UBSAN_OPTIONS=halt_on_error=1 \
ODBCSYSINI=. ODBCINSTINI=./odbcinst.ini ODBCINI=./odbc.ini \
  ./exe/descriptors-free-test
```

Result:

```text
connected
freeing attached application row descriptor
freeing attached application parameter descriptor
disconnecting
```