### PR TITLE
Avoid reading before leading string literals

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -3852,7 +3852,8 @@ inner_process_tokens(QueryParse *qp, QueryBuild *qb)
 			qp->escape_in_literal = CC_get_escape(qb->conn);
 			if (!qp->escape_in_literal)
 			{
-				if (LITERAL_EXT == F_OldPtr(qp)[-1])
+				if (qp->opos > 0 &&
+				    LITERAL_EXT == F_OldPtr(qp)[-1])
 					qp->escape_in_literal = ESCAPE_IN_LITERAL;
 			}
 		}

--- a/parse.c
+++ b/parse.c
@@ -157,7 +157,8 @@ getNextToken(
 				escape_in_literal = escape_ch;
 				if (!escape_in_literal)
 				{
-					if (LITERAL_EXT == tstr[-1])
+					if (tstr > (const UCHAR *) s &&
+					    LITERAL_EXT == tstr[-1])
 						escape_in_literal = ESCAPE_IN_LITERAL;
 				}
 			}

--- a/statement.c
+++ b/statement.c
@@ -1122,7 +1122,8 @@ SC_scanQueryAndCountParams(const char *query, const ConnectionClass *conn,
 				escape_in_literal = CC_get_escape(conn);
 				if (!escape_in_literal)
 				{
-					if (LITERAL_EXT == ENCODE_PTR(encstr)[-1])
+					if (encstr.pos > 0 &&
+					    LITERAL_EXT == ENCODE_PTR(encstr)[-1])
 						escape_in_literal = ESCAPE_IN_LITERAL;
 				}
 			}

--- a/test/expected/leading-literal-numparams.out
+++ b/test/expected/leading-literal-numparams.out
@@ -1,0 +1,3 @@
+connected
+nparams=0
+disconnecting

--- a/test/src/leading-literal-numparams-test.c
+++ b/test/src/leading-literal-numparams-test.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "common.h"
+
+int
+main(int argc, char **argv)
+{
+	HSTMT		hstmt = SQL_NULL_HSTMT;
+	SQLRETURN	rc;
+	SQLSMALLINT	nparams = -1;
+
+	test_connect();
+
+	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn, &hstmt);
+	CHECK_CONN_RESULT(rc, "SQLAllocHandle(SQL_HANDLE_STMT) failed", conn);
+
+	rc = SQLPrepare(hstmt, (SQLCHAR *) "'abc'", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "SQLPrepare failed", hstmt);
+
+	rc = SQLNumParams(hstmt, &nparams);
+	CHECK_STMT_RESULT(rc, "SQLNumParams failed", hstmt);
+	printf("nparams=%d\n", (int) nparams);
+
+	SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+	test_disconnect();
+
+	return 0;
+}

--- a/test/tests
+++ b/test/tests
@@ -19,6 +19,7 @@ TESTBINS = exe/connect-test \
 	exe/prepare-test \
 	exe/premature-test \
 	exe/params-test \
+	exe/leading-literal-numparams-test \
 	exe/param-conversions-test \
 	exe/parse-test \
 	exe/identity-test \


### PR DESCRIPTION
This fixes a one-byte read before the start of the prepared SQL buffer when
parameter counting sees a leading string literal while
standard_conforming_strings is on.

Call chain reproduced through unixODBC with an ASan build:

- SQLPrepare(hstmt, "'abc'", SQL_NTS) copies the SQL into the statement buffer.
- SQLNumParams(hstmt, ...) calls PGAPI_NumParams().
- PGAPI_NumParams() calls SC_scanQueryAndCountParams().
- SC_scanQueryAndCountParams() saw the leading quote, CC_get_escape() returned 0, and the E'' prefix check read ENCODE_PTR(encstr)[-1].

ASan before the fix reported:

- heap-buffer-overflow READ of size 1
- statement.c:1125 in SC_scanQueryAndCountParams
- address located 1 byte before the buffer allocated by make_string() from PGAPI_Prepare()

The patch guards the E'' prefix check in the three scanner paths so the previous
byte is read only when the current scanner position is not at the beginning of
the SQL string. This preserves E'' handling and avoids changing normal literal
parsing.

Verification in WSL:

- Built psqlodbc with -fsanitize=address,undefined
- Reproduced the ASan failure before the fix with exe/leading-literal-numparams-test
- Rebuilt after the fix and confirmed the same test prints nparams=0 without ASan errors
- Ran the project harness: ./runsuite leading-literal-numparams --inputdir=. -> ok 1
