### PR TITLE
Use signed type for error status

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -305,6 +305,8 @@ jobs:
         echo on
         C:\OTHERBIN\postgresql_install.exe --mode unattended --unattendedmodeui none --superpassword password --enable-components server
         sc config "postgresql-x64-17" start= auto
+        sc start "postgresql-x64-17"
+        timeout /t 5 /nobreak
 
     # -----------------------------------------------------------------
     # Build and test psqlodbc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ env:
 
   # PostgreSQL build from source.
   POSTGRESQL_SOURCE_TAG: 'REL_18_STABLE'
-  OPENSSL_VERSION: '3_5_6'
+  OPENSSL_VERSION: '3_5_7'
   PKGCONFIGLITE_VERSION: '0.28-1'
   WINFLEXBISON_VERSION: '2.5.24'
   WORKFLOW_VERSION_POSTGRESQL: '1' # increment to invalidate cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -306,7 +306,7 @@ jobs:
         C:\OTHERBIN\postgresql_install.exe --mode unattended --unattendedmodeui none --superpassword password --enable-components server
         sc config "postgresql-x64-17" start= auto
         sc start "postgresql-x64-17"
-        timeout /t 5 /nobreak
+        ping -n 6 127.0.0.1 >nul
 
     # -----------------------------------------------------------------
     # Build and test psqlodbc

--- a/psqlodbc.h
+++ b/psqlodbc.h
@@ -652,7 +652,7 @@ typedef struct QueryInfo_
 /*	Used to save the error information */
 typedef struct
 {
-        UInt4	status;
+        Int4	status;		/* statement warnings are negative */
 		UInt4	errsize;
         UInt4	errpos;
         UInt2	recsize;

--- a/winbuild/BuildAll.ps1
+++ b/winbuild/BuildAll.ps1
@@ -116,6 +116,7 @@ function buildPlatform([xml]$configInfo, [string]$Platform)
 			"15.0"	{ $mimallocIdeDir = "vs2017" }
 			"16.0"	{ $mimallocIdeDir = "vs2019" }
 			"17.0"	{ $mimallocIdeDir = "vs2022" }
+			"18.0"	{ $mimallocIdeDir = "vs2022" }
 			default { throw "Unable to resolve mimalloc IDE directory for VC ${VCVersion}."}
 		}
 

--- a/winbuild/MSProgram-Get.psm1
+++ b/winbuild/MSProgram-Get.psm1
@@ -70,6 +70,7 @@ function Find-MSBuild
 	 "15.0"	{ $toolsout = 15 }
 	 "16.0"	{ $toolsout = 16 }
 	 "17.0" { $toolsout = 17 }
+	 "18.0" { $toolsout = 18 }
 	 default { throw "Selected Visual Studio is Version ${VisualStudioVersion}. Please use VC10 or later"}
 	}
 #
@@ -154,6 +155,7 @@ function Find-MSBuild
 		 "15.0"	{$Toolsetv="v141_xp"}
 		 "16.0"	{$Toolsetv="v142"}
 		 "17.0" {$Toolsetv="v143"}
+		 "18.0" {$Toolsetv="v145"}
 		}
 	}
 #	avoid a bug of Windows7.1SDK PlatformToolset


### PR DESCRIPTION
## Problem

`PG_ErrorInfo.status` is currently declared as `UInt4`, but it stores signed diagnostic codes.

Statement warnings are explicitly represented by negative values, for example:

- `STMT_ERROR_IN_ROW = -6`
- `STMT_TRUNCATED = -2`
- `STMT_INFO_ONLY = -1`

Descriptor warnings also use negative values. The diagnostic value flows through the following path:

```text
StatementClass.__error_number (int)
    -> PG_ErrorInfo.status (UInt4)
    -> ODBC NativeError (SQLINTEGER)
```

As a result, a negative warning is first converted to an unsigned value and later converted back to a signed `SQLINTEGER`. The latter conversion is implementation-defined when the unsigned value is outside the signed range, and stricter compilers report a signed/unsigned conversion warning.

## Change

Change `PG_ErrorInfo.status` from `UInt4` to `Int4`.

This makes the field consistent with its existing value domain and keeps negative warning codes signed throughout the diagnostic path.

`Int4` and `UInt4` are the corresponding signed and unsigned `int` types, so this change does not alter the structure size or alignment. Existing positive error codes are unaffected.

## Validation

Built both the ANSI and Unicode drivers on Linux with GCC:

```sh
./bootstrap
./configure --with-unixodbc=__without_odbc_config
make -j4
```

The build completed successfully.
