### PR TITLE
Fix 'infinity'/'-infinity' date silently returned as today's date

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -1448,8 +1448,30 @@ MYLOG(0, "null_cvt_date_string=%d\n", conn->connInfo.cvt_null_date_string);
 		case PG_TYPE_DATE:
 			{
 				int status = 0;
-				secure_sscanf(value, &status, "%4d-%2d-%2d",
-				ARG_INT(&std_time.y), ARG_INT(&std_time.m), ARG_INT(&std_time.d));
+
+				/*
+				 * Unhandled, "infinity"/"-infinity" fail the sscanf
+				 * below and std_time is later filled with today's
+				 * date.  Mirror the PG_TYPE_TIMESTAMP handling below.
+				 */
+				std_time.infinity = 0;
+				if (strnicmp(value, INFINITY_STRING, 8) == 0)
+				{
+					std_time.infinity = 1;
+					std_time.y = 9999;
+					std_time.m = 12;
+					std_time.d = 31;
+				}
+				else if (strnicmp(value, MINFINITY_STRING, 9) == 0)
+				{
+					std_time.infinity = -1;
+					std_time.y = 1;
+					std_time.m = 1;
+					std_time.d = 1;
+				}
+				else
+					secure_sscanf(value, &status, "%4d-%2d-%2d",
+					ARG_INT(&std_time.y), ARG_INT(&std_time.m), ARG_INT(&std_time.d));
 			}		
 			break;
 

--- a/test/expected/cvtnulldate.out
+++ b/test/expected/cvtnulldate.out
@@ -3,4 +3,6 @@ Result set:
 1
 Result set:
 
+Result set:
+9999-12-31	0001-01-01
 disconnecting

--- a/test/src/cvtnulldate-test.c
+++ b/test/src/cvtnulldate-test.c
@@ -60,6 +60,14 @@ int main(int argc, char **argv)
 	rc = SQLFreeStmt(hstmt, SQL_CLOSE);
 	CHECK_STMT_RESULT(rc, "SQLFreeStmt failed", hstmt);
 
+	/* Check 'infinity'/'-infinity' date */
+	rc = SQLExecDirect(hstmt, (SQLCHAR *) "SELECT 'infinity'::date, '-infinity'::date", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "SQLExecDirect failed", hstmt);
+	print_result(hstmt);
+
+	rc = SQLFreeStmt(hstmt, SQL_CLOSE);
+	CHECK_STMT_RESULT(rc, "SQLFreeStmt failed", hstmt);
+
 	/* Clean up */
 	test_disconnect();
 


### PR DESCRIPTION
PG_TYPE_DATE never checked for these strings, unlike PG_TYPE_TIMESTAMP right below it, so the sscanf silently failed and a today's-date fallback meant for a different case kicked in instead. Mirror the timestamp handling, mapping to 0001-01-01 / 9999-12-31. Adds a regression case to cvtnulldate-test.