### PR TITLE
Fix statement rollback discarding the whole transaction on a syntax error (#203)

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -1875,7 +1875,7 @@ CC_send_query_append(ConnectionClass *self, const char *query, QueryInfo *qi, UD
 		create_keyset = ((flag & CREATE_KEYSET) != 0),
 		issue_begin = ((flag & GO_INTO_TRANSACTION) != 0 && !CC_is_in_trans(self)),
 		rollback_on_error, query_rollback, end_with_commit,
-		read_only, prepend_savepoint = FALSE,
+		read_only,
 		ignore_roundtrip_time = ((self->connInfo.extra_opts & BIT_IGNORE_ROUND_TRIP_TIME) != 0);
 
 	char		*ptr;
@@ -1979,16 +1979,12 @@ CC_send_query_append(ConnectionClass *self, const char *query, QueryInfo *qi, UD
 		}
 	}
 
-	/* prepend internal savepoint command ? */
-	if (PREPEND_IN_PROGRESS == self->internal_op)
-		prepend_savepoint = TRUE;
-
 	/* append all these together, to avoid round-trips */
 	query_len = strlen(query);
 	MYLOG(0, "query_len=" FORMAT_SIZE_T "\n", query_len);
 
 	initPQExpBuffer(&query_buf);
-	/* issue_begin, query_rollback and prepend_savepoint are exclusive */
+	/* issue_begin and query_rollback are exclusive */
 	if (issue_begin)
 	{
 		appendPQExpBuffer(&query_buf, "%s;", bgncmd);
@@ -1998,14 +1994,6 @@ CC_send_query_append(ConnectionClass *self, const char *query, QueryInfo *qi, UD
 	{
 		appendPQExpBuffer(&query_buf, "%s %s;", svpcmd, per_query_svp);
 		discard_next_savepoint = TRUE;
-	}
-	else if (prepend_savepoint)
-	{
-		char   	prepend_cmd[128];
-
-		GenerateSvpCommand(self, INTERNAL_SAVEPOINT_OPERATION, prepend_cmd, sizeof(prepend_cmd));
-		appendPQExpBuffer(&query_buf, "%s;", prepend_cmd);
-		self->internal_op = SAVEPOINT_IN_PROGRESS;
 	}
 	appendPQExpBufferStr(&query_buf, query);
 	if (appendq)

--- a/connection.h
+++ b/connection.h
@@ -521,7 +521,6 @@ int	GenerateSvpCommand(ConnectionClass *conn, int type, char *cmd, int bufsize);
 /*      Operations in progress */
 enum {
         SAVEPOINT_IN_PROGRESS = 1
-        ,PREPEND_IN_PROGRESS
 };
 /*      StatementSvp entry option */
 enum {

--- a/execute.c
+++ b/execute.c
@@ -812,12 +812,19 @@ MYLOG(DETAIL_LOG_LEVEL, " %p->accessed=%d opt=%u in_progress=%u prev=%u\n", conn
 		}
 		if (need_savep)
 		{
-			if (0 != (option & SVPOPT_REDUCE_ROUNDTRIP))
-			{
-				conn->internal_op = PREPEND_IN_PROGRESS;
-				CC_set_accessed_db(conn);
-				return ret;
-			}
+			/*
+			 * Establish the internal savepoint with its own round-trip
+			 * instead of prepending it to the user's statement.  Bundling
+			 * "SAVEPOINT ...; <statement>" into a single simple-query string
+			 * means a statement that fails at parse time (e.g. a syntax
+			 * error) takes the SAVEPOINT down with it: the SAVEPOINT never
+			 * executes, so statement-level rollback has no savepoint to roll
+			 * back to and the whole transaction is discarded, silently losing
+			 * work done earlier in the transaction (issue #203).  Sending the
+			 * SAVEPOINT separately guarantees it is in place before the
+			 * statement is parsed, at the cost of one extra round-trip per
+			 * rolled-back statement.
+			 */
 			GenerateSvpCommand(conn, INTERNAL_SAVEPOINT_OPERATION, cmd, sizeof(cmd));
 			conn->internal_op = SAVEPOINT_IN_PROGRESS;
 			res = CC_send_query(conn, cmd, NULL, 0, NULL);

--- a/test/expected/error-rollback.out
+++ b/test/expected/error-rollback.out
@@ -55,3 +55,21 @@ Result set:
 6
 7
 disconnecting
+Test for rollback protocol 2 error-class matrix (SSP=0)
+connected
+  ExecDirect syntax    : SQLSTATE=42601, marker=1, tx=alive
+  Prepare    syntax    : SQLSTATE=42601, marker=1, tx=alive
+  ExecDirect undef-rel : SQLSTATE=42P01, marker=1, tx=alive
+  Prepare    undef-rel : SQLSTATE=42P01, marker=1, tx=alive
+  ExecDirect bad-value : SQLSTATE=22P02, marker=1, tx=alive
+  Prepare    bad-value : SQLSTATE=22P02, marker=1, tx=alive
+disconnecting
+Test for rollback protocol 2 error-class matrix (SSP=1)
+connected
+  ExecDirect syntax    : SQLSTATE=42601, marker=1, tx=alive
+  Prepare    syntax    : SQLSTATE=42601, marker=1, tx=alive
+  ExecDirect undef-rel : SQLSTATE=42P01, marker=1, tx=alive
+  Prepare    undef-rel : SQLSTATE=42P01, marker=1, tx=alive
+  ExecDirect bad-value : SQLSTATE=22P02, marker=1, tx=alive
+  Prepare    bad-value : SQLSTATE=22P02, marker=1, tx=alive
+disconnecting

--- a/test/expected/rollback-syntax-error.out
+++ b/test/expected/rollback-syntax-error.out
@@ -1,0 +1,8 @@
+connected
+Case 1: syntax error must roll back only the statement
+  expected error, SQLSTATE=42601
+  rows visible after syntax error: 1
+Case 2: execution-time error rolls back only the statement
+  expected error, SQLSTATE=42P01
+  rows visible after exec-time error: 2
+disconnecting

--- a/test/src/error-rollback-test.c
+++ b/test/src/error-rollback-test.c
@@ -141,6 +141,145 @@ error_rollback_print(void)
 	print_result(hstmt);
 }
 
+/*
+ * Helpers for the error-class matrix below.
+ *
+ * The existing tests above cover just one error class (invalid integer input,
+ * 22P02) via SQLExecDirect.  With statement rollback (Protocol=7.4-2) the
+ * driver used to bundle "SAVEPOINT ...; <statement>" into a single simple-
+ * query string, which fails as a unit at parse time on grammar errors -- so
+ * a *syntax error* (42601) would silently roll back the whole transaction
+ * instead of just the offending statement (issue #203).  The matrix below
+ * exercises three error classes across ExecDirect and Prepare/Execute, and
+ * asserts (via a marker row) that earlier work in the transaction survives.
+ *
+ * Errors always surface at SQLExecute time (not SQLPrepare) for the paths
+ * this driver takes, so we only print the SQLSTATE, not where it fired.
+ */
+
+/* Extract the first SQLSTATE from a statement handle. */
+static void
+get_state(HSTMT s, char *out, size_t outlen)
+{
+	SQLCHAR		state[6] = {0};
+	SQLINTEGER	native;
+	SQLCHAR		msg[256];
+	SQLSMALLINT	len;
+
+	SQLGetDiagRec(SQL_HANDLE_STMT, s, 1, state,
+				  &native, msg, sizeof(msg), &len);
+	snprintf(out, outlen, "%s", (char *) state);
+}
+
+/* Run a statement expected to fail; print its SQLSTATE.  A different
+ * SQLSTATE, or unexpected success, is flagged inline so `diff` catches it. */
+static void
+expect_fail(HSTMT s, int use_prepare, const char *label,
+			const char *sql, const char *want_state)
+{
+	SQLRETURN	rc;
+	char		state[8] = {0};
+
+	if (use_prepare)
+	{
+		rc = SQLPrepare(s, (SQLCHAR *) sql, SQL_NTS);
+		if (SQL_SUCCEEDED(rc))
+			rc = SQLExecute(s);
+	}
+	else
+		rc = SQLExecDirect(s, (SQLCHAR *) sql, SQL_NTS);
+
+	if (SQL_SUCCEEDED(rc))
+	{
+		printf("%s: UNEXPECTED SUCCESS\n", label);
+		SQLFreeStmt(s, SQL_CLOSE);
+		return;
+	}
+	get_state(s, state, sizeof(state));
+	printf("%s: SQLSTATE=%s", label, state);
+	if (strcmp(state, want_state) != 0)
+		printf(" [MISMATCH want=%s]", want_state);
+	SQLFreeStmt(s, SQL_CLOSE);
+}
+
+/* After a failed statement, verify the marker row inserted earlier in the
+ * same transaction is still visible (statement-level rollback worked) and
+ * that the transaction is still usable. */
+static void
+check_survival(HSTMT s)
+{
+	SQLRETURN	rc;
+	SQLCHAR		buf[32];
+	SQLLEN		ind;
+
+	rc = SQLExecDirect(s, (SQLCHAR *)
+					   "SELECT count(*) FROM errortab WHERE i=100",
+					   SQL_NTS);
+	if (!SQL_SUCCEEDED(rc))
+	{
+		printf(", marker=<count query failed>, tx=ABORTED\n");
+		SQLFreeStmt(s, SQL_CLOSE);
+		return;
+	}
+	if (SQLFetch(s) != SQL_SUCCESS)
+	{
+		printf(", marker=<fetch failed>\n");
+		SQLFreeStmt(s, SQL_CLOSE);
+		return;
+	}
+	SQLGetData(s, 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+	printf(", marker=%s", (char *) buf);
+	SQLFreeStmt(s, SQL_CLOSE);
+
+	rc = SQLExecDirect(s, (SQLCHAR *) "SELECT 1", SQL_NTS);
+	printf(", tx=%s\n", SQL_SUCCEEDED(rc) ? "alive" : "ABORTED");
+	SQLFreeStmt(s, SQL_CLOSE);
+}
+
+/* Run one case: insert marker row, fail the given statement, then verify
+ * the marker row survives.  Each case rolls back at the end so the next
+ * case starts clean. */
+static void
+run_case(int use_prepare, const char *label,
+		 const char *sql, const char *want_state)
+{
+	SQLRETURN	rc;
+
+	rc = SQLExecDirect(hstmt, (SQLCHAR *)
+					   "INSERT INTO errortab VALUES (100)", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "marker insert failed", hstmt);
+	SQLFreeStmt(hstmt, SQL_CLOSE);
+
+	expect_fail(hstmt, use_prepare, label, sql, want_state);
+	check_survival(hstmt);
+
+	rc = SQLEndTran(SQL_HANDLE_DBC, conn, SQL_ROLLBACK);
+	CHECK_STMT_RESULT(rc, "SQLEndTran (case) failed", hstmt);
+}
+
+/* One matrix run: three error classes x two execution paths. */
+static void
+run_matrix(const char *options, const char *header)
+{
+	printf("%s\n", header);
+	error_rollback_init((char *) options);
+
+	run_case(0, "  ExecDirect syntax    ",
+			 "INSERT INTO errortab VALUS (1)", "42601");
+	run_case(1, "  Prepare    syntax    ",
+			 "INSERT INTO errortab VALUS (1)", "42601");
+	run_case(0, "  ExecDirect undef-rel ",
+			 "INSERT INTO no_such_tbl VALUES (1)", "42P01");
+	run_case(1, "  Prepare    undef-rel ",
+			 "INSERT INTO no_such_tbl VALUES (1)", "42P01");
+	run_case(0, "  ExecDirect bad-value ",
+			 "INSERT INTO errortab VALUES ('nope')", "22P02");
+	run_case(1, "  Prepare    bad-value ",
+			 "INSERT INTO errortab VALUES ('nope')", "22P02");
+
+	error_rollback_clean();
+}
+
 int
 main(int argc, char **argv)
 {
@@ -225,6 +364,24 @@ main(int argc, char **argv)
 
 	/* Clean up */
 	error_rollback_clean();
+
+	/*
+	 * Error-class matrix under Protocol=7.4-2.
+	 *
+	 * Each case inserts a marker row, then runs a statement expected to fail
+	 * with a particular SQLSTATE, then asserts the marker row is still there
+	 * (statement rollback worked) and the transaction is still usable.
+	 *
+	 * The syntax-error (42601) rows are the ones that broke pre-issue-#203
+	 * fix: on ExecDirect+SSP=0, Prepare+SSP=0 and ExecDirect+SSP=1 the whole
+	 * transaction was silently aborted, so the marker row disappeared.
+	 * The other classes and Prepare+SSP=1 have always worked; they're
+	 * included as regression guards.
+	 */
+	run_matrix("Protocol=7.4-2;UseServerSidePrepare=0",
+			   "Test for rollback protocol 2 error-class matrix (SSP=0)");
+	run_matrix("Protocol=7.4-2;UseServerSidePrepare=1",
+			   "Test for rollback protocol 2 error-class matrix (SSP=1)");
 
 	return 0;
 }

--- a/test/src/rollback-syntax-error-test.c
+++ b/test/src/rollback-syntax-error-test.c
@@ -1,0 +1,127 @@
+/*
+ * Regression test for issue #203.
+ *
+ * With statement-level rollback (Protocol 7.4-2), a *syntax* error must roll
+ * back only the offending statement, leaving earlier work in the transaction
+ * intact -- exactly like an execution-time error already does.
+ *
+ * The driver used to bundle "SAVEPOINT ...; <user statement>" into a single
+ * simple-query string.  A syntax error fails that whole string at parse time,
+ * so the SAVEPOINT never executed and the driver fell back to rolling back the
+ * entire transaction -- silently discarding earlier work (see the issue: a
+ * table lock obtained earlier was lost).  An execution-time error (e.g. a
+ * missing relation) did not hit this because the SAVEPOINT executed first.
+ *
+ * This test inserts a row, triggers each kind of error, and checks that the
+ * row is still visible afterwards (statement rolled back, transaction alive).
+ */
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "common.h"
+
+static HSTMT hstmt = SQL_NULL_HSTMT;
+
+/* Execute a statement expected to fail; print only its SQLSTATE (stable
+ * across server versions, unlike the message text). */
+static void
+exec_expect_error(const char *sql)
+{
+	SQLRETURN	rc;
+
+	rc = SQLExecDirect(hstmt, (SQLCHAR *) sql, SQL_NTS);
+	if (SQL_SUCCEEDED(rc))
+	{
+		printf("  ERROR: statement unexpectedly succeeded: %s\n", sql);
+		return;
+	}
+	{
+		SQLCHAR		state[6];
+		SQLINTEGER	native;
+		SQLCHAR		msg[512];
+		SQLSMALLINT	len;
+
+		if (SQL_SUCCEEDED(SQLGetDiagRec(SQL_HANDLE_STMT, hstmt, 1, state,
+										&native, msg, sizeof(msg), &len)))
+			printf("  expected error, SQLSTATE=%s\n", state);
+	}
+	SQLFreeStmt(hstmt, SQL_CLOSE);
+}
+
+static void
+exec_ok(const char *sql)
+{
+	SQLRETURN	rc;
+
+	rc = SQLExecDirect(hstmt, (SQLCHAR *) sql, SQL_NTS);
+	CHECK_STMT_RESULT(rc, "SQLExecDirect failed", hstmt);
+	SQLFreeStmt(hstmt, SQL_CLOSE);
+}
+
+/* Print how many rows are currently visible in rbtab. */
+static void
+show_rowcount(const char *label)
+{
+	SQLRETURN	rc;
+	SQLCHAR		buf[32];
+	SQLLEN		ind;
+
+	rc = SQLExecDirect(hstmt, (SQLCHAR *) "SELECT count(*) FROM rbtab", SQL_NTS);
+	CHECK_STMT_RESULT(rc, "count query failed", hstmt);
+	rc = SQLFetch(hstmt);
+	CHECK_STMT_RESULT(rc, "count fetch failed", hstmt);
+	rc = SQLGetData(hstmt, 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+	CHECK_STMT_RESULT(rc, "count getdata failed", hstmt);
+	printf("  %s: %s\n", label, (char *) buf);
+	SQLFreeStmt(hstmt, SQL_CLOSE);
+}
+
+int
+main(int argc, char **argv)
+{
+	SQLRETURN	rc;
+
+	test_connect_ext("Protocol=7.4-2");
+
+	rc = SQLAllocStmt(conn, &hstmt);
+	if (!SQL_SUCCEEDED(rc))
+	{
+		print_diag("failed to allocate stmt handle", SQL_HANDLE_DBC, conn);
+		exit(1);
+	}
+
+	rc = SQLSetConnectAttr(conn, SQL_ATTR_AUTOCOMMIT,
+						   (SQLPOINTER) SQL_AUTOCOMMIT_OFF, SQL_IS_UINTEGER);
+	CHECK_STMT_RESULT(rc, "SQLSetConnectAttr failed", hstmt);
+
+	/* A committed temp table gives us a clean, session-local slate. */
+	exec_ok("CREATE TEMPORARY TABLE rbtab (i int4)");
+	rc = SQLEndTran(SQL_HANDLE_DBC, conn, SQL_COMMIT);
+	CHECK_STMT_RESULT(rc, "SQLEndTran (create) failed", hstmt);
+
+	/*
+	 * Case 1: syntax error (parse-time).  This is the issue #203 case.
+	 * The row inserted before the error must survive.
+	 */
+	printf("Case 1: syntax error must roll back only the statement\n");
+	exec_ok("INSERT INTO rbtab VALUES (100)");
+	exec_expect_error("INSERT INTO rbtab VALUS (101)");   /* typo -> 42601 */
+	show_rowcount("rows visible after syntax error");
+
+	/*
+	 * Case 2: execution-time error (missing relation).  Same expectation;
+	 * this path already worked, so it guards against regressions.
+	 */
+	printf("Case 2: execution-time error rolls back only the statement\n");
+	exec_ok("INSERT INTO rbtab VALUES (200)");
+	exec_expect_error("INSERT INTO no_such_table_xyz VALUES (201)"); /* 42P01 */
+	show_rowcount("rows visible after exec-time error");
+
+	rc = SQLEndTran(SQL_HANDLE_DBC, conn, SQL_ROLLBACK);
+	CHECK_STMT_RESULT(rc, "SQLEndTran (rollback) failed", hstmt);
+
+	test_disconnect();
+
+	return 0;
+}

--- a/test/tests
+++ b/test/tests
@@ -50,6 +50,7 @@ TESTBINS = exe/connect-test \
 	exe/cte-test \
 	exe/errors-test \
 	exe/error-rollback-test \
+	exe/rollback-syntax-error-test \
 	exe/diagnostic-test \
 	exe/numeric-test \
 	exe/large-object-test \


### PR DESCRIPTION
## Problem

With statement-level rollback (`Protocol=7.4-2`, the default on PG >= 8.0), a statement that fails with a **syntax error** silently rolls back the *entire* transaction instead of just the failing statement -- discarding work already done in that transaction. The reporter observed a table `LOCK` obtained earlier being released, and the transaction ID advancing, after a malformed `LOCK ... IN POTATOS MODE`.

Confusingly, other errors (undefined relation, type-coercion, undefined column, etc.) behaved correctly -- only syntax errors triggered it -- which made it look like "a lottery."

Fixes #203.

## Root cause

To save a round-trip, the driver established the per-statement internal `SAVEPOINT` by **prepending it to the user's statement** and sending them as a single simple-query string:

```
RELEASE _EXEC_SVP_x; SAVEPOINT _EXEC_SVP_x; <user statement>
```

PostgreSQL parses a simple-query string *in full before executing any of it*. A statement that fails at **parse time** -- a syntax error (`SQLSTATE 42601`) -- fails the whole string, so the leading `SAVEPOINT` never runs. With no savepoint established, statement-level rollback has nothing to roll back to, and the driver falls back to aborting the whole transaction.

Execution-time errors (missing relation, bad value, etc.) are unaffected, because parsing succeeds and the `SAVEPOINT` executes before the failing statement is analyzed. That parse-time-vs-execution-time split is what made this look inconsistent.

## Fix

Send the internal `SAVEPOINT` as its **own round-trip**, before the user's statement, rather than bundling them into one parse unit (`SetStatementSvp` in `execute.c`). The savepoint is then guaranteed to be in place before the statement is parsed, so a syntax error rolls back only that statement and the transaction stays usable.

Also removes the now-unreachable prepend machinery (`PREPEND_IN_PROGRESS` and its handling in `CC_send_query_append`).

## Performance impact

This changes savepoint establishment from *bundled* (0 extra messages) to a *separate* round-trip, so it adds **one extra round-trip for every statement except the first in a transaction**, under `Protocol=7.4-2` with autocommit off. This is a proactive savepoint taken before nearly every statement -- **not** only before ones that fail -- and it includes read `SELECT`s.

Measured wire traffic for `INSERT; INSERT; SELECT; INSERT` (autocommit off, `7.4-2`):

**Before -- 5 round-trips (savepoint bundled with each statement):**
```
BEGIN;INSERT INTO rt VALUES (1)
SAVEPOINT ...;INSERT INTO rt VALUES (2)
RELEASE ...;SAVEPOINT ...;SELECT count(*) FROM rt
RELEASE ...;SAVEPOINT ...;INSERT INTO rt VALUES (3)
ROLLBACK
```

**After -- 8 round-trips (savepoint sent separately):**
```
BEGIN;INSERT INTO rt VALUES (1)
SAVEPOINT ...
INSERT INTO rt VALUES (2)
RELEASE ...;SAVEPOINT ...
SELECT count(*) FROM rt
RELEASE ...;SAVEPOINT ...
INSERT INTO rt VALUES (3)
ROLLBACK
```

So an N-statement transaction incurs roughly **N-1 extra round-trips** (nearly 2x the message count). On a high-latency link this is a real slowdown. It is the price of correctness -- the previous behavior could silently discard work already done in a transaction.

**Not affected:** the first statement of each transaction (bundled with `BEGIN`), autocommit-on connections, and `Protocol=7.4-0`/`7.4-1` (no statement-level rollback, no savepoints).

A future optimization could restore the single round-trip by piggybacking the *next* statement's `SAVEPOINT` onto the *previous* statement's send; that is a larger change and is intentionally out of scope here. Maintainer input welcome on whether to ship this straightforward fix now and optimize later, or gate the old bundling behavior behind an option.

## Testing

Verified against PostgreSQL 18 via unixODBC.

- **New** `rollback-syntax-error-test`: inserts a row, triggers a syntax error, and asserts the row survives (statement-only rollback) -- plus an execution-time-error guard.
- **Extended** `error-rollback-test` with an error-class matrix under `7.4-2`: three error classes (`42601` syntax, `42P01` undefined relation, `22P02` bad value) x two execution paths (`SQLExecDirect`, `SQLPrepare`/`SQLExecute`) x `UseServerSidePrepare` 0/1, each asserting a marker row survives. This is the coverage gap that let the bug through -- the pre-existing test only exercised execution-time errors.

Both tests fail on `main` (row/transaction lost on syntax error) and pass with this change. Existing transaction/cursor/error regression tests remain green (the one `params` diff is a pre-existing PG18 baseline mismatch, confirmed identical on the unmodified driver).
