### PR TITLE
ci: bump Windows OpenSSL to 3.5.8 (3.5.7 rotated out, 404)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ env:
 
   # PostgreSQL build from source.
   POSTGRESQL_SOURCE_TAG: 'REL_18_STABLE'
-  OPENSSL_VERSION: '3_5_7'
+  OPENSSL_VERSION: '3_5_8'
   WORKFLOW_VERSION_POSTGRESQL_ARM64: '1' # increment to invalidate the arm64 cache
   PKGCONFIGLITE_VERSION: '0.28-1'
   WINFLEXBISON_VERSION: '2.5.24'


### PR DESCRIPTION
## Problem

The `build-postgres` and `build-postgres-arm` jobs are failing on every branch at the "Install Win32/Win64 OpenSSL" step with:

```
The system cannot execute the specified program.
```

slproweb.com only hosts the **latest** OpenSSL patch release and has rotated from 3.5.7 to 3.5.8, so `Win32OpenSSL-3_5_7.exe`, `Win64OpenSSL-3_5_7.exe` and `Win64ARMOpenSSL-3_5_7.exe` now return **404**. The download step saves the 404 error page as `*.exe`, and the subsequent install step can't execute it. When `build-postgres` fails, the Windows `build-and-test` jobs are skipped.

## Fix

Bump `OPENSSL_VERSION` from `3_5_7` to `3_5_8`. Verified all three installers are currently available:

- `Win32OpenSSL-3_5_8.exe` -> 200
- `Win64OpenSSL-3_5_8.exe` -> 200
- `Win64ARMOpenSSL-3_5_8.exe` -> 200

The single env var drives every OpenSSL URL and cache key (x86, x64, ARM64), so this one-line change covers all jobs.

## Note

This is the third slproweb patch-rotation break recently (3.5.5 -> 3.5.6 -> 3.5.7 -> 3.5.8). A more durable fix would avoid pinning to slproweb's exact-patch URLs (e.g. a fallback list or a stable OpenSSL source). Worth a follow-up; this PR just unblocks CI now.
