### PR TITLE
Redact the DB password (ODBC PWD and libpq pqopt password) in debug logs

### DIFF
--- a/dlg_specific.c
+++ b/dlg_specific.c
@@ -687,9 +687,19 @@ copyConnAttributes(ConnInfo *ci, const char *attribute, const char *value)
 	}
 	else if (stricmp(attribute, INI_PQOPT) == 0 || stricmp(attribute, ABBR_PQOPT) == 0)
 	{
+		char	*hide_str = hide_password(value);
+
 		NULL_THE_NAME(ci->pqopt);
 		ci->pqopt_in_str = TRUE;
 		ci->pqopt = decode_or_remove_braces(value);
+		/*
+		 * A pqopt value can embed a libpq 'password=...', so log a copy
+		 * with the password masked and skip the generic logging below.
+		 */
+		MYLOG(0, "key='%s' value='%s'\n", attribute, hide_str ? hide_str : "");
+		if (hide_str)
+			free(hide_str);
+		printed = TRUE;
 	}
 	else if (stricmp(attribute, INI_UPDATABLECURSORS) == 0 || stricmp(attribute, ABBR_UPDATABLECURSORS) == 0)
 		ci->allow_keyset = pg_atoi(value);

--- a/drvconn.c
+++ b/drvconn.c
@@ -37,10 +37,13 @@
 
 #include "dlg_specific.h"
 
-#define	FORCE_PASSWORD_DISPLAY
 #define	NULL_IF_NULL(a) (a ? a : "(NULL)")
 
-#ifndef FORCE_PASSWORD_DISPLAY
+/*
+ * Mask the password in a connection string before it is written to the log,
+ * so that debug logs (MyLog/CommLog) can be shared without leaking the
+ * database credentials.  Matches the PWD keyword case-insensitively.
+ */
 static char * hide_password(const char *str)
 {
 	char *outstr, *pwdp;
@@ -48,9 +51,12 @@ static char * hide_password(const char *str)
 	if (!str)	return NULL;
 	outstr = strdup(str);
 	if (!outstr) return NULL;
-	if (pwdp = strstr(outstr, "PWD="), !pwdp)
-		pwdp = strstr(outstr, "pwd=");
-	if (pwdp)
+	for (pwdp = outstr; *pwdp; pwdp++)
+	{
+		if (strnicmp(pwdp, "PWD=", 4) == 0)
+			break;
+	}
+	if (*pwdp)
 	{
 		char	*p;
 
@@ -59,7 +65,6 @@ static char * hide_password(const char *str)
 	}
 	return outstr;
 }
-#endif
 
 /* prototypes */
 static BOOL dconn_get_DSN_or_Driver(const char *connect_string, ConnInfo *ci);
@@ -308,8 +313,8 @@ MYLOG(DETAIL_LOG_LEVEL, "before CC_connect\n");
 		char	*hide_str = NULL;
 
 		if (cbConnStrOutMax > 0)
-			hide_str = hide_password(szConnStrOut);
-		MYLOG(0, "szConnStrOut = '%s' len=%d,%d\n", NULL_IF_NULL(hide_str), len, cbConnStrOutMax);
+			hide_str = hide_password((char *) szConnStrOut);
+		MYLOG(0, "szConnStrOut = '%s' len=" FORMAT_SSIZE_T ",%d\n", NULL_IF_NULL(hide_str), len, cbConnStrOutMax);
 		if (hide_str)
 			free(hide_str);
 	}

--- a/drvconn.c
+++ b/drvconn.c
@@ -39,33 +39,6 @@
 
 #define	NULL_IF_NULL(a) (a ? a : "(NULL)")
 
-/*
- * Mask the password in a connection string before it is written to the log,
- * so that debug logs (MyLog/CommLog) can be shared without leaking the
- * database credentials.  Matches the PWD keyword case-insensitively.
- */
-static char * hide_password(const char *str)
-{
-	char *outstr, *pwdp;
-
-	if (!str)	return NULL;
-	outstr = strdup(str);
-	if (!outstr) return NULL;
-	for (pwdp = outstr; *pwdp; pwdp++)
-	{
-		if (strnicmp(pwdp, "PWD=", 4) == 0)
-			break;
-	}
-	if (*pwdp)
-	{
-		char	*p;
-
-		for (p=pwdp + 4; *p && *p != ';'; p++)
-			*p = 'x';
-	}
-	return outstr;
-}
-
 /* prototypes */
 static BOOL dconn_get_DSN_or_Driver(const char *connect_string, ConnInfo *ci);
 static BOOL dconn_get_connect_attributes(const char *connect_string, ConnInfo *ci);

--- a/misc.c
+++ b/misc.c
@@ -312,3 +312,59 @@ quote_table(const pgNAME schema, const pgNAME table, char *buf, int buf_size)
 
 	return buf;
 }
+
+/*
+ * Return a malloc'd copy of a connection string with any password value
+ * masked, so that debug logs (MyLog/CommLog) can be shared without leaking
+ * the database credentials.  Both keywords are matched case-insensitively:
+ *
+ *   PWD=       the ODBC password attribute; its value runs to the next ';'
+ *   password=  the libpq password keyword, e.g. inside a pqopt={...} value;
+ *              its value is whitespace-delimited (or single-quoted) and ends
+ *              at the closing brace of the pqopt block.
+ *
+ * The caller is responsible for free()ing the returned string.
+ */
+char *
+hide_password(const char *str)
+{
+	char	*outstr, *p;
+
+	if (!str)
+		return NULL;
+	outstr = strdup(str);
+	if (!outstr)
+		return NULL;
+	for (p = outstr; *p; )
+	{
+		if (strnicmp(p, "PWD=", 4) == 0)
+		{
+			for (p += 4; *p && *p != ';'; p++)
+				*p = 'x';
+		}
+		else if (strnicmp(p, "password=", 9) == 0)
+		{
+			p += 9;
+			if (*p == '\'')		/* libpq single-quoted value */
+			{
+				for (p++; *p && *p != '\''; p++)
+				{
+					if (*p == '\\' && p[1])
+						*p++ = 'x';
+					*p = 'x';
+				}
+				if (*p == '\'')
+					p++;
+			}
+			else
+			{
+				for (; *p && *p != ';' && *p != '}' &&
+				       *p != ' ' && *p != '\t'; p++)
+					*p = 'x';
+			}
+		}
+		else
+			p++;
+	}
+	return outstr;
+}

--- a/misc.h
+++ b/misc.h
@@ -98,6 +98,12 @@ FUNCTION_BEGIN_MACRO \
 FUNCTION_END_MACRO
 
 
+/*
+ * Return a malloc'd copy of a connection string with password values masked,
+ * for safe logging.  The caller must free() the result.
+ */
+char *hide_password(const char *str);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Problem

`hide_password()` exists to mask the password in a connection string before it is written to the log, so that MyLog/CommLog output can be shared for debugging without leaking the database credentials.

It was compiled out by an unconditional `#define FORCE_PASSWORD_DISPLAY` (present since 2013). With MyLog (`Debug`) enabled, the driver therefore logged the full connection string -- including the password in **cleartext**.

Two forms of password leaked:
1. The ODBC `PWD=` attribute (`connStrIn`, `szConnStrOut`, `our_connect_string` log sites in drvconn.c).
2. A libpq `password=` embedded in a `pqopt={...}` value -- via `szConnStrOut` and via the per-attribute logging in `copyConnAttributes` (dlg_specific.c). `hide_password()` did not know about the libpq `password=` keyword.

Reproduced against PostgreSQL 18 for both forms, including a single-quoted `pqopt={... password='my secret'}`.

## Fix

- Remove the `FORCE_PASSWORD_DISPLAY` define so the existing redaction branches are actually used.
- Move `hide_password()` to `misc.c` so it can be shared, and teach it to mask **both** keywords, case-insensitively:
  - `PWD=` -- ODBC attribute; value runs to the next `;`.
  - `password=` -- libpq keyword (e.g. inside `pqopt`); value is whitespace-delimited or single-quoted (backslash escapes honored) and ends at the closing brace.
- Redact the `pqopt` value where `copyConnAttributes` logs it, and skip the generic raw logging for that key. Non-secret pqopt fields (host, sslmode, application_name, ...) stay visible for debugging.
- Fix the pointer-sign and format (`ssize_t`) warnings in the `szConnStrOut` redaction branch that were previously never compiled.

After the fix the same connections log `PWD=xxxx`, `password=xxxx`, and `password='xxxx'` (quoted) -- verified with `PWD=`/`pwd=`/`Pwd=` and unquoted/quoted pqopt passwords; no cleartext remains.

## Scope / severity

Logging is **off by default** (`mylog_on = 0`; the `MYLOG` macro is a no-op and no log file is created unless debug logging is explicitly enabled), so this only affected users who turned on debug tracing, and additionally required access to the resulting log file. No default-on exposure, no remote vector. Low-severity hardening (CWE-532); no CVE.

Reported-by: @Alpop12
