### PR TITLE
Leave length/indicator untouched on out-of-range overflow (follow-up to #210)

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -2151,8 +2151,12 @@ MYLOG(DETAIL_LOG_LEVEL, "SQL_C_VARBOOKMARK value=%d\n", ival);
 		}
 	}
 
-	/* store the length of what was copied, if there's a place for it */
-	if (pcbValue)
+	/*
+	 * Store the length of what was copied, if there's a place for it.
+	 * On an out-of-range overflow the data buffer is left untouched, so
+	 * leave the length/indicator untouched too (issue #207).
+	 */
+	if (pcbValue && result != COPY_RESULT_OVERFLOW)
 		*pcbValueBindRow = len;
 
 	if (result == COPY_OK && stmt->current_col >= 0)


### PR DESCRIPTION
Follow-up to #210 (merged), addressing the review note on that PR: on the out-of-range `SQL_ERROR` path the data buffer is left untouched, but the length/indicator was still set to the C type's size (4 or 2).

This skips the length/indicator write when the conversion overflows (`result == COPY_RESULT_OVERFLOW`), for symmetry with the untouched data buffer. Within spec either way (buffer and indicator are undefined after `SQL_ERROR`).

Verified on PostgreSQL 18: `int-overflow` and `result-conversions` tests still pass; error rows no longer report the C-type size in the indicator.
